### PR TITLE
Fix hybrid markdown rendering inverted logic

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -298,10 +298,10 @@ export const Editor = forwardRef<EditorRef, EditorProps>(
     // Use useLayoutEffect to ensure synchronous execution before paint
     // This prevents the "unfocused block stays in marker mode" issue when navigating up
     useLayoutEffect(() => {
-      if (editorViewRef.current && latestRef.current.isFocused !== undefined) {
+      if (editorViewRef.current && isFocused !== undefined) {
         editorViewRef.current.dispatch({
           effects: isFocusedCompartment.reconfigure(
-            isFocusedFacet.of(latestRef.current.isFocused),
+            isFocusedFacet.of(isFocused),
           ),
         });
       }

--- a/src/editor/extensions/handlers/BlockRefHandler.ts
+++ b/src/editor/extensions/handlers/BlockRefHandler.ts
@@ -275,7 +275,7 @@ export class BlockRefHandler extends BaseHandler {
   static processLine(
     lineText: string,
     lineFrom: number,
-    shouldShowMarkers: boolean,
+    isEditMode: boolean,
   ): DecorationSpec[] {
     const decorations: DecorationSpec[] = [];
 
@@ -284,9 +284,9 @@ export class BlockRefHandler extends BaseHandler {
       const from = lineFrom + match.start;
       const to = lineFrom + match.end;
 
-      // If cursor is on this line, don't hide anything and don't show widgets
-      // This allows the user to edit the source code
-      if (shouldShowMarkers) {
+      // In edit mode, show raw markdown for editing
+      // Don't hide anything and don't show widgets
+      if (isEditMode) {
         continue;
       }
 

--- a/src/editor/extensions/handlers/BlockquoteHandler.ts
+++ b/src/editor/extensions/handlers/BlockquoteHandler.ts
@@ -28,7 +28,6 @@ export class BlockquoteHandler extends BaseHandler {
     const decorations: DecorationSpec[] = [];
     const line = this.getNodeLine(node, context);
     const lineText = line.text;
-    const isOnCursor = this.isOnCursorLine(node, context);
 
     // Blockquote format: > text
     const match = lineText.match(/^(>\s*)/);
@@ -38,9 +37,9 @@ export class BlockquoteHandler extends BaseHandler {
 
     const markerEnd = line.from + match[1].length;
 
-    // Hide/dim the > marker
+    // Hide/dim the > marker based on edit mode
     decorations.push(
-      createHiddenMarker(line.from, markerEnd, isOnCursor)
+      createHiddenMarker(line.from, markerEnd, context.isEditMode),
     );
 
     // Style the blockquote content
@@ -49,7 +48,7 @@ export class BlockquoteHandler extends BaseHandler {
         createStyledText(markerEnd, line.to, {
           className: "cm-blockquote",
           style: getBlockquoteStyle(),
-        })
+        }),
       );
     }
 

--- a/src/editor/extensions/handlers/CalloutHandler.ts
+++ b/src/editor/extensions/handlers/CalloutHandler.ts
@@ -91,7 +91,7 @@ export class CalloutHandler extends BaseHandler {
   static processLine(
     lineText: string,
     lineFrom: number,
-    shouldShowMarkers: boolean,
+    isEditMode: boolean,
   ): DecorationSpec[] {
     const decorations: DecorationSpec[] = [];
 
@@ -107,8 +107,8 @@ export class CalloutHandler extends BaseHandler {
 
       const config = this.CALLOUT_TYPES[calloutType] || this.CALLOUT_TYPES.note;
 
-      // Hide the > [!type] part when not on cursor line
-      if (!shouldShowMarkers) {
+      // Hide the > [!type] part in preview mode
+      if (!isEditMode) {
         const syntaxEnd = lineText.indexOf(title);
         if (syntaxEnd > 0) {
           decorations.push({

--- a/src/editor/extensions/handlers/CommentHandler.ts
+++ b/src/editor/extensions/handlers/CommentHandler.ts
@@ -33,7 +33,7 @@ export class CommentHandler extends BaseHandler {
   static processLine(
     lineText: string,
     lineFrom: number,
-    shouldShowMarkers: boolean,
+    isEditMode: boolean,
   ): DecorationSpec[] {
     const decorations: DecorationSpec[] = [];
 
@@ -45,8 +45,8 @@ export class CommentHandler extends BaseHandler {
       const start = lineFrom + match.index;
       const end = start + match[0].length;
 
-      if (shouldShowMarkers) {
-        // Show dimmed comment when cursor is on line
+      if (isEditMode) {
+        // Show dimmed comment in edit mode
         decorations.push({
           from: start,
           to: end,
@@ -65,7 +65,7 @@ export class CommentHandler extends BaseHandler {
           }),
         });
       } else {
-        // Completely hide comment when cursor is not on line
+        // Completely hide comment in preview mode
         decorations.push({
           from: start,
           to: end,

--- a/src/editor/extensions/handlers/EmphasisHandler.ts
+++ b/src/editor/extensions/handlers/EmphasisHandler.ts
@@ -27,7 +27,6 @@ export class EmphasisHandler extends BaseHandler {
   handle(node: SyntaxNode, context: RenderContext): DecorationSpec[] {
     const decorations: DecorationSpec[] = [];
     const content = this.getNodeText(node, context);
-    const isOnCursor = this.isOnCursorLine(node, context);
 
     // Emphasis is wrapped with * or _
     // Format: *text* or _text_
@@ -38,10 +37,14 @@ export class EmphasisHandler extends BaseHandler {
     }
 
     // Opening marker (first character)
-    decorations.push(createHiddenMarker(node.from, node.from + 1, isOnCursor));
+    decorations.push(
+      createHiddenMarker(node.from, node.from + 1, context.isEditMode),
+    );
 
     // Closing marker (last character)
-    decorations.push(createHiddenMarker(node.to - 1, node.to, isOnCursor));
+    decorations.push(
+      createHiddenMarker(node.to - 1, node.to, context.isEditMode),
+    );
 
     // Style the content between markers
     if (node.from + 1 < node.to - 1) {

--- a/src/editor/extensions/handlers/HeadingHandler.ts
+++ b/src/editor/extensions/handlers/HeadingHandler.ts
@@ -2,8 +2,8 @@
  * Heading handler for hybrid rendering
  *
  * Handles ATX-style headings (# H1, ## H2, etc.)
- * - Hides hash marks when cursor is not on line
- * - Shows dimmed hash marks when editing
+ * - Hides hash marks in preview mode (block unfocused)
+ * - Shows dimmed hash marks in edit mode (block focused)
  * - Applies appropriate font size and weight based on heading level
  */
 
@@ -41,11 +41,10 @@ export class HeadingHandler extends BaseHandler {
     const hashEnd = line.from + hashMarks.length;
     const level = hashMarks.length;
 
-    // Check if cursor is on this line
-    const isOnCursor = this.isOnCursorLine(node, context);
-
-    // Hide/dim the hash marks
-    decorations.push(createHiddenMarker(line.from, hashEnd, isOnCursor));
+    // Hide/dim the hash marks based on edit mode
+    decorations.push(
+      createHiddenMarker(line.from, hashEnd, context.isEditMode),
+    );
 
     // Style the heading text (if there is any)
     if (hashEnd < line.to) {

--- a/src/editor/extensions/handlers/HighlightHandler.ts
+++ b/src/editor/extensions/handlers/HighlightHandler.ts
@@ -36,7 +36,7 @@ export class HighlightHandler extends BaseHandler {
   static processLine(
     lineText: string,
     lineFrom: number,
-    shouldShowMarkers: boolean,
+    isEditMode: boolean,
   ): DecorationSpec[] {
     const decorations: DecorationSpec[] = [];
 
@@ -51,7 +51,7 @@ export class HighlightHandler extends BaseHandler {
       const contentEnd = end - 2;
 
       // Hide opening ==
-      decorations.push(createHiddenMarker(start, start + 2, shouldShowMarkers));
+      decorations.push(createHiddenMarker(start, start + 2, isEditMode));
 
       // Style the highlighted content
       decorations.push(
@@ -67,7 +67,7 @@ export class HighlightHandler extends BaseHandler {
       );
 
       // Hide closing ==
-      decorations.push(createHiddenMarker(end - 2, end, shouldShowMarkers));
+      decorations.push(createHiddenMarker(contentEnd, end, isEditMode));
     }
 
     return decorations;

--- a/src/editor/extensions/handlers/InlineCodeHandler.ts
+++ b/src/editor/extensions/handlers/InlineCodeHandler.ts
@@ -28,7 +28,6 @@ export class InlineCodeHandler extends BaseHandler {
   handle(node: SyntaxNode, context: RenderContext): DecorationSpec[] {
     const decorations: DecorationSpec[] = [];
     const content = this.getNodeText(node, context);
-    const isOnCursor = this.isOnCursorLine(node, context);
 
     // Inline code is wrapped with backticks
     // Format: `code`
@@ -37,10 +36,14 @@ export class InlineCodeHandler extends BaseHandler {
     }
 
     // Opening backtick
-    decorations.push(createHiddenMarker(node.from, node.from + 1, isOnCursor));
+    decorations.push(
+      createHiddenMarker(node.from, node.from + 1, context.isEditMode),
+    );
 
     // Closing backtick
-    decorations.push(createHiddenMarker(node.to - 1, node.to, isOnCursor));
+    decorations.push(
+      createHiddenMarker(node.to - 1, node.to, context.isEditMode),
+    );
 
     // Style the code content between backticks
     if (node.from + 1 < node.to - 1) {

--- a/src/editor/extensions/handlers/LinkHandler.ts
+++ b/src/editor/extensions/handlers/LinkHandler.ts
@@ -28,7 +28,6 @@ export class LinkHandler extends BaseHandler {
   handle(node: SyntaxNode, context: RenderContext): DecorationSpec[] {
     const decorations: DecorationSpec[] = [];
     const content = this.getNodeText(node, context);
-    const isOnCursor = this.isOnCursorLine(node, context);
 
     // Link format: [text](url)
     // We need to parse it to find the boundaries
@@ -46,7 +45,9 @@ export class LinkHandler extends BaseHandler {
     const urlEnd = urlStart + url.length;
 
     // Hide opening bracket [
-    decorations.push(createHiddenMarker(node.from, node.from + 1, isOnCursor));
+    decorations.push(
+      createHiddenMarker(node.from, node.from + 1, context.isEditMode),
+    );
 
     // Style the link text
     decorations.push(
@@ -57,13 +58,13 @@ export class LinkHandler extends BaseHandler {
     );
 
     // Hide ]( between text and URL
-    decorations.push(createHiddenMarker(textEnd, urlStart, isOnCursor));
+    decorations.push(createHiddenMarker(textEnd, urlStart, context.isEditMode));
 
     // Hide/dim the URL
-    decorations.push(createHiddenMarker(urlStart, urlEnd, isOnCursor));
+    decorations.push(createHiddenMarker(urlStart, urlEnd, context.isEditMode));
 
     // Hide closing parenthesis )
-    decorations.push(createHiddenMarker(urlEnd, node.to, isOnCursor));
+    decorations.push(createHiddenMarker(urlEnd, node.to, context.isEditMode));
 
     return decorations;
   }

--- a/src/editor/extensions/handlers/StrongHandler.ts
+++ b/src/editor/extensions/handlers/StrongHandler.ts
@@ -27,7 +27,6 @@ export class StrongHandler extends BaseHandler {
   handle(node: SyntaxNode, context: RenderContext): DecorationSpec[] {
     const decorations: DecorationSpec[] = [];
     const content = this.getNodeText(node, context);
-    const isOnCursor = this.isOnCursorLine(node, context);
 
     // Strong emphasis is wrapped with ** or __
     // Format: **text** or __text__
@@ -40,12 +39,16 @@ export class StrongHandler extends BaseHandler {
 
     // Opening markers (first 2 characters)
     decorations.push(
-      createHiddenMarker(node.from, node.from + markerLength, isOnCursor),
+      createHiddenMarker(
+        node.from,
+        node.from + markerLength,
+        context.isEditMode,
+      ),
     );
 
     // Closing markers (last 2 characters)
     decorations.push(
-      createHiddenMarker(node.to - markerLength, node.to, isOnCursor),
+      createHiddenMarker(node.to - markerLength, node.to, context.isEditMode),
     );
 
     // Style the content between markers

--- a/src/editor/extensions/handlers/TagHandler.ts
+++ b/src/editor/extensions/handlers/TagHandler.ts
@@ -37,7 +37,7 @@ export class TagHandler extends BaseHandler {
   static processLine(
     lineText: string,
     lineFrom: number,
-    _shouldShowMarkers: boolean,
+    _isEditMode: boolean,
   ): DecorationSpec[] {
     const decorations: DecorationSpec[] = [];
 

--- a/src/editor/extensions/handlers/TaskListHandler.ts
+++ b/src/editor/extensions/handlers/TaskListHandler.ts
@@ -45,14 +45,13 @@ export class TaskListHandler extends BaseHandler {
 
     // Add checkbox widget at the start of the line
     decorations.push(
-      createWidget(line.from, new CheckboxWidget(checked, line.from), 1)
+      createWidget(line.from, new CheckboxWidget(checked, line.from), 1),
     );
 
     // Hide the markdown checkbox syntax
-    // Show dimmed if cursor is on this line
-    const isOnCursor = this.isOnCursorLine(node, context);
+    // Show dimmed in edit mode
     decorations.push(
-      createHiddenMarker(markerEnd, checkboxEnd, isOnCursor)
+      createHiddenMarker(markerEnd, checkboxEnd, context.isEditMode),
     );
 
     return decorations;

--- a/src/editor/extensions/handlers/WikiLinkHandler.ts
+++ b/src/editor/extensions/handlers/WikiLinkHandler.ts
@@ -135,11 +135,15 @@ export class WikiLinkHandler extends BaseHandler {
   /**
    * Process wiki links in a line of text
    * Called manually from the main rendering loop
+   *
+   * @param lineText - The text content of the line
+   * @param lineFrom - The absolute position of the line start in the document
+   * @param isEditMode - true if block is in edit mode (focused), false if in preview mode (unfocused)
    */
   static processLine(
     lineText: string,
     lineFrom: number,
-    shouldShowMarkers: boolean,
+    isEditMode: boolean,
   ): DecorationSpec[] {
     const decorations: DecorationSpec[] = [];
 
@@ -154,9 +158,9 @@ export class WikiLinkHandler extends BaseHandler {
       const start = lineFrom + embedMatch.index;
       const end = start + fullMatch.length;
 
-      // If cursor is on this line, don't hide anything and don't show widgets
-      // This allows the user to edit the source code
-      if (shouldShowMarkers) {
+      // In edit mode, show raw markdown for editing
+      // Don't hide anything and don't show widgets
+      if (isEditMode) {
         continue;
       }
 
@@ -187,9 +191,9 @@ export class WikiLinkHandler extends BaseHandler {
       const start = lineFrom + match.index;
       const end = start + fullMatch.length;
 
-      // If cursor is on this line, don't hide anything
+      // In edit mode, show raw markdown for editing
       // This allows the user to edit the source code and see autocomplete
-      if (shouldShowMarkers) {
+      if (isEditMode) {
         continue;
       }
 

--- a/src/editor/extensions/handlers/types.ts
+++ b/src/editor/extensions/handlers/types.ts
@@ -25,11 +25,11 @@ export interface RenderContext {
   editorHasFocus: boolean;
 
   /**
-   * Whether markdown markers should be visible (edit mode)
-   * - true: show markers dimmed (editing mode - block has focus)
-   * - false: hide markers completely (preview mode - block unfocused)
+   * Whether the block is in edit mode (has focus)
+   * - true: edit mode - show markers dimmed (block has focus, user is editing)
+   * - false: preview mode - hide markers completely (block unfocused, show rendered)
    */
-  shouldShowMarkers: boolean;
+  isEditMode: boolean;
 
   /** Array to collect decoration specs */
   decorations: DecorationSpec[];
@@ -80,10 +80,10 @@ export abstract class BaseHandler implements DecorationHandler {
 
   /**
    * Helper to check if node is on cursor line
-   * @deprecated Use context.shouldShowMarkers instead for consistent behavior
+   * @deprecated Use context.isEditMode instead for consistent behavior
    */
   protected isOnCursorLine(_node: SyntaxNode, context: RenderContext): boolean {
-    return context.shouldShowMarkers;
+    return context.isEditMode;
   }
 
   /**

--- a/src/editor/extensions/utils/decorationHelpers.ts
+++ b/src/editor/extensions/utils/decorationHelpers.ts
@@ -53,21 +53,25 @@ export function isPositionOnCursorLine(
 /**
  * Create a decoration that hides markdown markers
  *
- * The marker will be completely hidden when the cursor is not on the line,
- * and dimmed/visible when the cursor is on the line for editing.
+ * The marker will be completely hidden in preview mode (block unfocused),
+ * and dimmed/visible in edit mode (block has focus) for editing.
+ *
+ * @param from - Start position
+ * @param to - End position
+ * @param isEditMode - true if block is in edit mode (focused), false if in preview mode (unfocused)
  */
 export function createHiddenMarker(
   from: number,
   to: number,
-  isOnCursor: boolean,
+  isEditMode: boolean,
 ): DecorationSpec {
   return {
     from,
     to,
     decoration: Decoration.mark({
-      class: isOnCursor ? "cm-dim-marker" : "cm-hidden",
+      class: isEditMode ? "cm-dim-marker" : "cm-hidden",
       attributes: {
-        style: getMarkerStyle(isOnCursor),
+        style: getMarkerStyle(isEditMode),
       },
     }),
   };
@@ -168,10 +172,10 @@ export function createWidget(
  */
 export function createHiddenMarkers(
   ranges: Array<{ from: number; to: number }>,
-  isOnCursor: boolean,
+  isEditMode: boolean,
 ): DecorationSpec[] {
   return ranges.map((range) =>
-    createHiddenMarker(range.from, range.to, isOnCursor),
+    createHiddenMarker(range.from, range.to, isEditMode),
   );
 }
 
@@ -257,10 +261,10 @@ export function createPairedMarkers(
   openTo: number,
   closeFrom: number,
   closeTo: number,
-  isOnCursor: boolean,
+  isEditMode: boolean,
 ): DecorationSpec[] {
   return [
-    createHiddenMarker(openFrom, openTo, isOnCursor),
-    createHiddenMarker(closeFrom, closeTo, isOnCursor),
+    createHiddenMarker(openFrom, openTo, isEditMode),
+    createHiddenMarker(closeFrom, closeTo, isEditMode),
   ];
 }


### PR DESCRIPTION
Fixes #3

## Problem
The hybrid markdown rendering system had inverted logic between initial render state and cursor focus state, creating an Othello-like situation where fixing one broke the other.

## Root Causes
1. **Semantic inversion**: Variable name 'shouldShowMarkers' was ambiguous about WHEN markers should be shown
2. **Inconsistent handler logic**: Different handlers used opposite logic directions
3. **Race condition**: Focus state facet updated with stale values from latestRef
4. **No-op function**: shouldShowMarkersForLine() just returned input unchanged

## Changes
- Renamed shouldShowMarkers to isEditMode (true = editing, false = preview)
- Removed shouldShowMarkersForLine() no-op function
- Unified all handlers to use context.isEditMode consistently
- HeadingHandler now uses block-level focus instead of cursor position
- Updated all processLine methods to use isEditMode parameter
- Fixed focus state race condition: use isFocused prop directly instead of latestRef

## Result
✓ Edit mode (isEditMode=true): Show dimmed markers for editing
✓ Preview mode (isEditMode=false): Hide markers completely, show rendered
✓ All handlers now behave consistently
✓ Focus state propagates immediately without race condition