### PR TITLE
chore(ci): add macOS code signing and notarization

### DIFF
--- a/.changeset/brave-foxs-run.md
+++ b/.changeset/brave-foxs-run.md
@@ -1,0 +1,17 @@
+---
+"oxinot": minor
+---
+
+- add automatic changeset generation via Git hooks
+- convert auto-changeset to CommonJS format
+- add null safety checks to auto-changeset script
+- add comprehensive GitHub issue and PR templates
+- use ubuntu-22.04 for webkit2gtk compatibility
+- resolve tauri config duplicate key and ci compatibility
+- relax biome rules and make CI lint non-blocking
+- remove invalid biome format check command
+- auto-close PRs when CI fails
+- remove invalid tauri macOS bundle settings
+- add timezone, indent size, and cache clear settings
+- enhance settings modal UI with theme and update options
+- prevent duplicate timezone in Select component

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,24 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Import Code-Signing Certificates for macOS
+        if: matrix.platform == 'macos-latest'
+        uses: Apple-Actions/import-codesign-certs@v2
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
       - name: Build and Release
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENABLE_CODE_SIGNING: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Oxinot ${{ github.ref_name }}"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,9 @@
       "icons/icon.ico"
     ],
     "macOS": {
-      "signingIdentity": null
+      "signingIdentity": null,
+      "entitlements": null,
+      "provisioningProfile": null
     }
   },
   "app": {


### PR DESCRIPTION
Add Apple Developer ID Application certificate signing and notarization support for macOS builds in GitHub Actions release workflow.

## Changes
- Import code-signing certificates using Apple-Actions/import-codesign-certs
- Configure environment variables for signing identity and notarization
- Add entitlements and provisioning profile fields to tauri.conf.json

This enables automated signing of DMG files for distribution outside the Mac App Store via GitHub Releases.

## Testing
Will be tested on the next release tag.