### PR TITLE
fix(ci): fix macOS signing config and target only macOS Silicon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,7 @@ env:
 
 jobs:
   build-and-release:
-    strategy:
-      matrix:
-        platform: [macos-latest, ubuntu-22.04, windows-latest]
-    runs-on: ${{ matrix.platform }}
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -22,12 +19,6 @@ jobs:
         with:
           node-version: lts/*
           cache: "npm"
-
-      - name: Install system dependencies (Ubuntu)
-        if: matrix.platform == 'ubuntu-22.04'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libayatana-appindicator3-dev librsvg2-dev patchelf
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -41,7 +32,6 @@ jobs:
         run: npm install
 
       - name: Import Code-Signing Certificates for macOS
-        if: matrix.platform == 'macos-latest'
         uses: Apple-Actions/import-codesign-certs@v2
         with:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,9 +20,7 @@
       "icons/icon.ico"
     ],
     "macOS": {
-      "signingIdentity": null,
-      "entitlements": null,
-      "provisioningProfile": null
+      "signingIdentity": null
     }
   },
   "app": {


### PR DESCRIPTION
Fix macOS code signing configuration issues and streamline release workflow.

## Changes
- Remove unsupported `provisioningProfile` and `entitlements` fields from tauri.conf.json
- Change release workflow to build only for macOS Silicon (macos-latest)
- Remove Ubuntu and Windows builds temporarily

## Fixes
- Resolves Tauri configuration error: 'Additional properties are not allowed'
- Simplifies initial release to macOS only