### PR TITLE
fix(ci): add write permissions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 env:
   RUST_BACKTRACE: 1
 


### PR DESCRIPTION
Add `contents: write` permission to release workflow to allow GitHub Actions to create releases.

## Fixes
- Resolves "Resource not accessible by integration" error when creating releases