### PR TITLE
feat(updater): add auto-update configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Oxinot ${{ github.ref_name }}"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,6 +24,14 @@
     }
   },
   "app": {
+    "updater": {
+      "active": true,
+      "endpoints": [
+        "https://github.com/0010capacity/oxinot/releases/latest/download/latest.json"
+      ],
+      "dialog": true,
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZBOEZGMDRFNTdDN0Y0NEYKUldSUDlNZFhUdkNQYWtDeDZZYzl6WmxuQ1hsS3p5R0VSdDVOZVNLWGJoNXVqNWY0bE1DTFJEN1MK"
+    },
     "windows": [
       {
         "title": "Oxinot",


### PR DESCRIPTION
Add Tauri updater configuration with signing keys for automatic app updates.

## Changes
- Configure updater endpoint to GitHub releases
- Add public key for update signature verification  
- Add signing environment variables to release workflow
- Enable update dialog for user notifications

## Related
Closes #19

## Note
Requires GitHub Secrets to be added:
- `TAURI_SIGNING_PRIVATE_KEY`
- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`