### PR TITLE
fix(config): move updater config to top level

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -9,6 +9,7 @@
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run build"
   },
+
   "bundle": {
     "active": true,
     "targets": "all",
@@ -23,15 +24,15 @@
       "signingIdentity": null
     }
   },
+  "updater": {
+    "active": true,
+    "endpoints": [
+      "https://github.com/0010capacity/oxinot/releases/latest/download/latest.json"
+    ],
+    "dialog": true,
+    "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZBOEZGMDRFNTdDN0Y0NEYKUldSUDlNZFhUdkNQYWtDeDZZYzl6WmxuQ1hsS3p5R0VSdDVOZVNLWGJoNXVqNWY0bE1DTFJEN1MK"
+  },
   "app": {
-    "updater": {
-      "active": true,
-      "endpoints": [
-        "https://github.com/0010capacity/oxinot/releases/latest/download/latest.json"
-      ],
-      "dialog": true,
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZBOEZGMDRFNTdDN0Y0NEYKUldSUDlNZFhUdkNQYWtDeDZZYzl6WmxuQ1hsS3p5R0VSdDVOZVNLWGJoNXVqNWY0bE1DTFJEN1MK"
-    },
     "windows": [
       {
         "title": "Oxinot",


### PR DESCRIPTION
Move updater configuration from `app` to top level in tauri.conf.json to fix configuration error.

## Fixes
- Resolves "Additional properties are not allowed ('updater' was unexpected)" error

## Changes
- Move `updater` config from `app` section to top level