### PR TITLE
fix(config): remove updater config temporarily

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,14 +24,6 @@
       "signingIdentity": null
     }
   },
-  "updater": {
-    "active": true,
-    "endpoints": [
-      "https://github.com/0010capacity/oxinot/releases/latest/download/latest.json"
-    ],
-    "dialog": true,
-    "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZBOEZGMDRFNTdDN0Y0NEYKUldSUDlNZFhUdkNQYWtDeDZZYzl6WmxuQ1hsS3p5R0VSdDVOZVNLWGJoNXVqNWY0bE1DTFJEN1MK"
-  },
   "app": {
     "windows": [
       {


### PR DESCRIPTION
Remove updater configuration from tauri.conf.json as it's not supported in the current Tauri version.

## Note
Will be added back when implementing the update UI in Issue #19.