### PR TITLE
fix(config): add updater to bundle config for Tauri 2

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -9,7 +9,6 @@
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run build"
   },
-
   "bundle": {
     "active": true,
     "targets": "all",
@@ -22,6 +21,14 @@
     ],
     "macOS": {
       "signingIdentity": null
+    },
+    "updater": {
+      "active": true,
+      "endpoints": [
+        "https://github.com/0010capacity/oxinot/releases/latest/download/latest.json"
+      ],
+      "dialog": true,
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZBOEZGMDRFNTdDN0Y0NEYKUldSUDlNZFhUdkNQYWtDeDZZYzl6WmxuQ1hsS3p5R0VSdDVOZVNLWGJoNXVqNWY0bE1DTFJEN1MK"
     }
   },
   "app": {


### PR DESCRIPTION
Move updater configuration into bundle section as required by Tauri 2.

## Fixes
- Resolves "Additional properties are not allowed ('updater' was unexpected)" error
- Updater config now properly placed in `bundle` section instead of top level