### PR TITLE
fix(config): place updater settings under plugins

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,13 +23,15 @@
       "signingIdentity": null
     }
   },
-  "updater": {
-    "active": true,
-    "endpoints": [
-      "https://github.com/0010capacity/oxinot/releases/latest/download/latest.json"
-    ],
-    "dialog": true,
-    "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZBOEZGMDRFNTdDN0Y0NEYKUldSUDlNZFhUdkNQYWtDeDZZYzl6WmxuQ1hsS3p5R0VSdDVOZVNLWGJoNXVqNWY0bE1DTFJEN1MK"
+  "plugins": {
+    "updater": {
+      "active": true,
+      "endpoints": [
+        "https://github.com/0010capacity/oxinot/releases/latest/download/latest.json"
+      ],
+      "dialog": true,
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZBOEZGMDRFNTdDN0Y0NEYKUldSUDlNZFhUdkNQYWtDeDZZYzl6WmxuQ1hsS3p5R0VSdDVOZVNLWGJoNXVqNWY0bE1DTFJEN1MK"
+    }
   },
   "app": {
     "windows": [


### PR DESCRIPTION
Move updater configuration under the plugins section to match tauri-plugin-updater expectations.

Fixes build error: 'Additional properties are not allowed ("updater" was unexpected)'.

Related: #19