### PR TITLE
docs(workflow): add comment to auto-changeset workflow

### DIFF
--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -1,5 +1,7 @@
 name: Auto Changeset
 
+# This workflow automatically generates changesets when PRs are merged to main
+
 on:
   pull_request:
     types: [closed]


### PR DESCRIPTION
Small test PR to verify auto-changeset workflow works after bypass configuration.

This should NOT generate a changeset since it's a 'docs' type commit.