### PR TITLE
improve(workflow): create PR for changesets instead of direct push

### DIFF
--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -17,6 +17,7 @@ jobs:
       cancel-in-progress: false
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,12 +48,32 @@ jobs:
             echo "No changeset generated (no qualifying commits)"
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
+            # Get changeset filename
+            CHANGESET_FILE=$(git diff --staged --name-only | grep ".changeset/" | head -1)
+            CHANGESET_NAME=$(basename "$CHANGESET_FILE" .md)
+            echo "changeset_name=$CHANGESET_NAME" >> $GITHUB_OUTPUT
           fi
 
-      - name: Commit and push changeset
+      - name: Create Pull Request
+        if: steps.check.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: auto-generate changeset"
+          branch: changeset/${{ steps.check.outputs.changeset_name }}
+          delete-branch: true
+          title: "chore: auto-generate changeset"
+          body: |
+            Automatically generated changeset from merged PR.
+
+            This PR will be auto-merged when CI passes.
+          labels: changeset
+
+      - name: Enable auto-merge
         if: steps.check.outputs.has_changes == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -m "chore: auto-generate changeset [skip ci]"
-          git push origin main
+          sleep 5
+          PR_NUMBER=$(gh pr list --head changeset/${{ steps.check.outputs.changeset_name }} --json number -q '.[0].number')
+          gh pr merge $PR_NUMBER --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Current workflow tries to push changesets directly to main, which fails due to branch protection rules requiring PRs.

## Solution

- Use `peter-evans/create-pull-request` action to create PR
- Auto-enable merge on the created PR
- Changeset PR will auto-merge when CI passes

## Benefits

- ✅ No token expiration issues (uses GITHUB_TOKEN)
- ✅ Respects branch protection rules
- ✅ Fully automated (auto-merge enabled)
- ✅ Changeset changes are reviewable (if needed)

## Workflow

1. PR merges to main
2. Auto-changeset workflow runs
3. Creates changeset PR (e.g., `changeset/happy-cats-jump`)
4. CI runs on changeset PR
5. Auto-merges when CI passes
6. Done! ✨