### PR TITLE
fix(workflow): replace peter-evans action with gh CLI

### DIFF
--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -54,26 +54,38 @@ jobs:
             echo "changeset_name=$CHANGESET_NAME" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create Pull Request
-        if: steps.check.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: auto-generate changeset"
-          branch: changeset/${{ steps.check.outputs.changeset_name }}
-          delete-branch: true
-          title: "chore: auto-generate changeset"
-          body: |
-            Automatically generated changeset from merged PR.
-
-            This PR will be auto-merged when CI passes.
-          labels: changeset
-
-      - name: Enable auto-merge
+      - name: Commit and push changeset
         if: steps.check.outputs.has_changes == 'true'
         run: |
-          sleep 5
-          PR_NUMBER=$(gh pr list --head changeset/${{ steps.check.outputs.changeset_name }} --json number -q '.[0].number')
-          gh pr merge $PR_NUMBER --auto --squash
+          BRANCH_NAME="changeset/${{ steps.check.outputs.changeset_name }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH_NAME"
+          git commit -m "chore: auto-generate changeset"
+          git push origin "$BRANCH_NAME"
+
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+        id: commit
+
+      - name: Create Pull Request
+        if: steps.check.outputs.has_changes == 'true'
+        run: |
+          PR_URL=$(gh pr create \
+            --title "chore: auto-generate changeset" \
+            --body "Automatically generated changeset from merged PR.
+
+This PR will be auto-merged when CI passes." \
+            --label changeset \
+            --head "${{ steps.commit.outputs.branch_name }}")
+
+          echo "Created PR: $PR_URL"
+
+          # Extract PR number and enable auto-merge
+          PR_NUMBER=$(echo "$PR_URL" | grep -oP '\d+$')
+          gh pr merge "$PR_NUMBER" --auto --squash
+
+          echo "Auto-merge enabled for PR #$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

peter-evans/create-pull-request action fails with 'Unexpected end of JSON input' error.

## Solution

Replace with manual approach:
- Git commit and push to changeset branch
- Use `gh pr create` to create PR
- Use `gh pr merge --auto` to enable auto-merge

## Benefits

- ✅ More reliable
- ✅ Better error messages
- ✅ Simpler to debug
- ✅ No third-party action dependency