### PR TITLE
feat(i18n): add initial i18n support with English and Korean locales

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,10 +28,13 @@
         "@tauri-apps/api": "^2.9.1",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.9.0",
+        "i18next": "^25.7.4",
+        "i18next-browser-languagedetector": "^8.2.0",
         "immer": "^11.1.3",
         "markdown-it": "^14.0.0",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
+        "react-i18next": "^16.5.2",
         "react-virtuoso": "^4.18.1",
         "uuid": "^13.0.0",
         "zustand": "^4.4.7"
@@ -3460,6 +3463,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -3474,6 +3486,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.7.4",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.7.4.tgz",
+      "integrity": "sha512-hRkpEblXXcXSNbw8mBNq9042OEetgyB/ahc/X17uV/khPwzV+uB8RHceHh3qavyrkPJvmXFKXME2Sy1E0KjAfw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/ignore": {
@@ -4116,6 +4168,33 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.2.tgz",
+      "integrity": "sha512-GG/SBVxx9dvrO1uCs8VYdKfOP8NEBUhNP+2VDQLCifRJ8DL1qPq296k2ACNGyZMDe7iyIlz/LMJTQOs8HXSRvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.6.2",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -4596,7 +4675,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4875,6 +4954,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-keyname": {

--- a/package.json
+++ b/package.json
@@ -42,10 +42,13 @@
     "@tauri-apps/api": "^2.9.1",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.9.0",
+    "i18next": "^25.7.4",
+    "i18next-browser-languagedetector": "^8.2.0",
     "immer": "^11.1.3",
     "markdown-it": "^14.0.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "react-i18next": "^16.5.2",
     "react-virtuoso": "^4.18.1",
     "uuid": "^13.0.0",
     "zustand": "^4.4.7"

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   Modal,
   Stack,
@@ -30,6 +31,7 @@ import {
   IconSearch,
   IconPlus,
   IconX,
+  IconLanguage,
 } from "@tabler/icons-react";
 import {
   useThemeStore,
@@ -78,6 +80,7 @@ export function SettingsModal({
   pagesById,
   pageIds,
 }: SettingsModalProps) {
+  const { t, i18n } = useTranslation();
   const colorScheme = useColorScheme();
   const isDark = colorScheme === "dark";
 
@@ -280,9 +283,9 @@ export function SettingsModal({
     // Define searchable content for each tab
     const tabContent: Record<string, string[]> = {
       appearance: [
-        "font family",
-        "editor font size",
-        "line height",
+        t("settings.appearance.font_family").toLowerCase(),
+        t("settings.appearance.editor_font_size").toLowerCase(),
+        t("settings.appearance.editor_line_height").toLowerCase(),
         "typography",
         "inter",
         "system",
@@ -291,24 +294,24 @@ export function SettingsModal({
         "preview",
       ],
       theme: [
-        "color mode",
-        "light",
-        "dark",
-        "auto",
-        "color variant",
+        t("settings.theme.color_mode").toLowerCase(),
+        t("settings.theme.modes.light").toLowerCase(),
+        t("settings.theme.modes.dark").toLowerCase(),
+        t("settings.theme.modes.auto").toLowerCase(),
+        t("settings.theme.color_variant").toLowerCase(),
         "accent",
-        "default",
-        "blue",
-        "purple",
-        "green",
-        "amber",
+        t("settings.theme.variants.default").toLowerCase(),
+        t("settings.theme.variants.blue").toLowerCase(),
+        t("settings.theme.variants.purple").toLowerCase(),
+        t("settings.theme.variants.green").toLowerCase(),
+        t("settings.theme.variants.amber").toLowerCase(),
       ],
       datetime: [
-        "time format",
+        t("settings.datetime.time_format").toLowerCase(),
         "24 hour",
         "12 hour",
-        "date order",
-        "date separator",
+        t("settings.datetime.date_order").toLowerCase(),
+        t("settings.datetime.date_separator").toLowerCase(),
         "mdy",
         "dmy",
         "ymd",
@@ -317,55 +320,76 @@ export function SettingsModal({
         "dot",
         "clock",
       ],
-      daily: ["daily notes path", "folder", "path", "daily"],
+      daily: [
+        t("settings.daily_notes.path").toLowerCase(),
+        "folder",
+        "path",
+        "daily",
+      ],
       homepage: [
-        "homepage type",
-        "daily note",
-        "file tree",
-        "index",
-        "custom page",
+        t("settings.homepage.type").toLowerCase(),
+        t("settings.homepage.types.daily_note").toLowerCase(),
+        t("settings.homepage.types.index").toLowerCase(),
+        t("settings.homepage.types.custom_page").toLowerCase(),
+        t("settings.homepage.custom_page").toLowerCase(),
         "start page",
         "default",
       ],
       outliner: [
-        "indent guides",
-        "auto expand",
-        "block count",
+        t("settings.outliner.indent_guides").toLowerCase(),
+        t("settings.outliner.auto_expand").toLowerCase(),
+        t("settings.outliner.block_count").toLowerCase(),
+        t("settings.outliner.code_block_line_numbers").toLowerCase(),
+        t("settings.outliner.indent_size").toLowerCase(),
         "blocks",
         "code block",
         "line numbers",
       ],
       git: [
-        "version control",
+        t("settings.git.title").toLowerCase(),
         "git",
         "repository",
         "commit",
-        "auto commit",
-        "remote",
+        t("settings.git.auto_commit").toLowerCase(),
+        t("settings.git.remote_repo").toLowerCase(),
         "push",
         "pull",
         "interval",
         "status",
       ],
       shortcuts: [
-        "keyboard shortcuts",
+        t("settings.shortcuts.title").toLowerCase(),
         "hotkey",
-        "command palette",
-        "search",
-        "settings",
+        t("settings.shortcuts.command_palette").toLowerCase(),
+        t("settings.shortcuts.search").toLowerCase(),
+        t("settings.shortcuts.toggle_index").toLowerCase(),
         "help",
         "toggle",
       ],
       advanced: [
-        "automatic updates",
-        "beta updates",
+        t("settings.advanced.updates").toLowerCase(),
+        t("settings.advanced.beta_updates").toLowerCase(),
         "check updates",
-        "telemetry",
-        "developer",
-        "reset settings",
+        t("settings.advanced.telemetry").toLowerCase(),
+        t("settings.advanced.developer_options").toLowerCase(),
+        t("settings.advanced.reset_settings").toLowerCase(),
         "danger",
       ],
-      about: ["version", "changelog", "beta", "oxinot", "info", "update"],
+      about: [
+        "version",
+        "changelog",
+        "beta",
+        "oxinot",
+        "info",
+        "update",
+        t("settings.about.updates_title").toLowerCase(),
+      ],
+      language: [
+        t("settings.language.title").toLowerCase(),
+        "english",
+        "korean",
+        "locale",
+      ],
     };
 
     return tabContent[tabValue]?.some((item) => item.includes(query)) ?? false;
@@ -378,10 +402,10 @@ export function SettingsModal({
       title={
         <Group gap="xs">
           <Text size="lg" fw={600}>
-            Settings
+            {t("settings.title")}
           </Text>
           <Badge size="sm" variant="light" color="blue">
-            Beta
+            {t("settings.beta")}
           </Badge>
         </Group>
       }
@@ -402,7 +426,7 @@ export function SettingsModal({
         }}
       >
         <TextInput
-          placeholder="Search settings..."
+          placeholder={t("settings.search_placeholder")}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.currentTarget.value)}
           leftSection={<IconSearch size={16} />}
@@ -418,8 +442,7 @@ export function SettingsModal({
         />
         {searchQuery && (
           <Text size="xs" c="dimmed" mt={8}>
-            Search is active. If you don't see any matching sections, try a
-            different keyword.
+            {t("settings.search_active")}
           </Text>
         )}
       </div>
@@ -443,37 +466,42 @@ export function SettingsModal({
               value="appearance"
               leftSection={<IconAppWindow size={16} />}
             >
-              Appearance
+              {t("settings.tabs.appearance")}
+            </Tabs.Tab>
+          )}
+          {hasMatchInTab("language") && (
+            <Tabs.Tab value="language" leftSection={<IconLanguage size={16} />}>
+              {t("settings.tabs.language")}
             </Tabs.Tab>
           )}
           {hasMatchInTab("theme") && (
             <Tabs.Tab value="theme" leftSection={<IconPalette size={16} />}>
-              Theme
+              {t("settings.tabs.theme")}
             </Tabs.Tab>
           )}
           {hasMatchInTab("datetime") && (
             <Tabs.Tab value="datetime" leftSection={<IconClock size={16} />}>
-              Date & Time
+              {t("settings.tabs.datetime")}
             </Tabs.Tab>
           )}
           {hasMatchInTab("daily") && (
             <Tabs.Tab value="daily" leftSection={<IconCalendar size={16} />}>
-              Daily Notes
+              {t("settings.tabs.daily_notes")}
             </Tabs.Tab>
           )}
           {hasMatchInTab("homepage") && (
             <Tabs.Tab value="homepage" leftSection={<IconHome size={16} />}>
-              Homepage
+              {t("settings.tabs.homepage")}
             </Tabs.Tab>
           )}
           {hasMatchInTab("outliner") && (
             <Tabs.Tab value="outliner" leftSection={<IconList size={16} />}>
-              Outliner
+              {t("settings.tabs.outliner")}
             </Tabs.Tab>
           )}
           {hasMatchInTab("git") && (
             <Tabs.Tab value="git" leftSection={<IconBrandGit size={16} />}>
-              Version Control
+              {t("settings.tabs.version_control")}
             </Tabs.Tab>
           )}
           {hasMatchInTab("shortcuts") && (
@@ -481,17 +509,17 @@ export function SettingsModal({
               value="shortcuts"
               leftSection={<IconKeyboard size={16} />}
             >
-              Shortcuts
+              {t("settings.tabs.shortcuts")}
             </Tabs.Tab>
           )}
           {hasMatchInTab("advanced") && (
             <Tabs.Tab value="advanced" leftSection={<IconSettings size={16} />}>
-              Advanced
+              {t("settings.tabs.advanced")}
             </Tabs.Tab>
           )}
           {hasMatchInTab("about") && (
             <Tabs.Tab value="about" leftSection={<IconSettings size={16} />}>
-              About
+              {t("settings.tabs.about")}
             </Tabs.Tab>
           )}
         </Tabs.List>
@@ -509,17 +537,17 @@ export function SettingsModal({
             <Stack gap="xl">
               <div>
                 <Text size="xl" fw={600} mb="lg">
-                  Appearance
+                  {t("settings.appearance.title")}
                 </Text>
                 <Text size="sm" c="dimmed" mb="xl">
-                  Customize the look and feel of the editor
+                  {t("settings.appearance.description")}
                 </Text>
 
                 <Stack gap="lg">
-                  {matchesSearch("Font Family") && (
+                  {matchesSearch(t("settings.appearance.font_family")) && (
                     <div>
                       <Text size="sm" fw={500} mb={8}>
-                        Font Family
+                        {t("settings.appearance.font_family")}
                       </Text>
                       <Select
                         value={fontFamily}
@@ -527,11 +555,11 @@ export function SettingsModal({
                           if (value) setFontFamily(value as FontFamily);
                         }}
                         data={FONT_OPTIONS}
-                        placeholder="Select font"
+                        placeholder={t("settings.appearance.font_family")}
                         searchable
                       />
                       <Text size="xs" c="dimmed" mt={4}>
-                        Choose the font used throughout the application
+                        {t("settings.appearance.font_family_desc")}
                       </Text>
                       <div
                         style={{
@@ -557,10 +585,10 @@ export function SettingsModal({
                     </div>
                   )}
 
-                  {matchesSearch("Editor Font Size") && (
+                  {matchesSearch(t("settings.appearance.editor_font_size")) && (
                     <div>
                       <Text size="sm" fw={500} mb={8}>
-                        Editor Font Size
+                        {t("settings.appearance.editor_font_size")}
                       </Text>
                       <Group gap="md" align="center">
                         <Slider
@@ -586,15 +614,17 @@ export function SettingsModal({
                         </Text>
                       </Group>
                       <Text size="xs" c="dimmed" mt={4}>
-                        Adjust the font size in the editor
+                        {t("settings.appearance.editor_font_size_desc")}
                       </Text>
                     </div>
                   )}
 
-                  {matchesSearch("Editor Line Height") && (
+                  {matchesSearch(
+                    t("settings.appearance.editor_line_height"),
+                  ) && (
                     <div>
                       <Text size="sm" fw={500} mb={8}>
-                        Editor Line Height
+                        {t("settings.appearance.editor_line_height")}
                       </Text>
                       <Group gap="md" align="center">
                         <Slider
@@ -619,10 +649,41 @@ export function SettingsModal({
                         </Text>
                       </Group>
                       <Text size="xs" c="dimmed" mt={4}>
-                        Adjust spacing between lines
+                        {t("settings.appearance.editor_line_height_desc")}
                       </Text>
                     </div>
                   )}
+                </Stack>
+              </div>
+            </Stack>
+          </Tabs.Panel>
+
+          {/* Language Tab */}
+          <Tabs.Panel value="language">
+            <Stack gap="xl">
+              <div>
+                <Text size="xl" fw={600} mb="lg">
+                  {t("settings.tabs.language")}
+                </Text>
+                <Text size="sm" c="dimmed" mb="xl">
+                  {t("settings.language.description")}
+                </Text>
+
+                <Stack gap="lg">
+                  <div>
+                    <Text size="sm" fw={500} mb={8}>
+                      {t("settings.language.select")}
+                    </Text>
+                    <Select
+                      value={i18n.language}
+                      onChange={(value) => i18n.changeLanguage(value || "en")}
+                      data={[
+                        { label: "English", value: "en" },
+                        { label: "한국어", value: "ko" },
+                      ]}
+                      allowDeselect={false}
+                    />
+                  </div>
                 </Stack>
               </div>
             </Stack>
@@ -633,14 +694,14 @@ export function SettingsModal({
             <Stack gap="xl">
               <div>
                 <Text size="xl" fw={600} mb="lg">
-                  Theme
+                  {t("settings.theme.title")}
                 </Text>
 
                 <Stack gap="lg">
-                  {matchesSearch("color mode light dark") && (
+                  {matchesSearch(t("settings.theme.color_mode")) && (
                     <div>
                       <Text size="sm" fw={500} mb={8}>
-                        Color Mode
+                        {t("settings.theme.color_mode")}
                       </Text>
                       <SegmentedControl
                         value={colorMode}
@@ -648,19 +709,28 @@ export function SettingsModal({
                           setColorMode(value as "light" | "dark" | "auto")
                         }
                         data={[
-                          { label: "Light", value: "light" },
-                          { label: "Dark", value: "dark" },
-                          { label: "Auto", value: "auto" },
+                          {
+                            label: t("settings.theme.modes.light"),
+                            value: "light",
+                          },
+                          {
+                            label: t("settings.theme.modes.dark"),
+                            value: "dark",
+                          },
+                          {
+                            label: t("settings.theme.modes.auto"),
+                            value: "auto",
+                          },
                         ]}
                         fullWidth
                       />
                     </div>
                   )}
 
-                  {matchesSearch("Color Variant accent") && (
+                  {matchesSearch(t("settings.theme.color_variant")) && (
                     <div>
                       <Text size="sm" fw={500} mb={8}>
-                        Color Variant
+                        {t("settings.theme.color_variant")}
                       </Text>
                       <SegmentedControl
                         value={colorVariant}
@@ -668,11 +738,26 @@ export function SettingsModal({
                           setColorVariant(value as ColorVariant)
                         }
                         data={[
-                          { label: "Default", value: "default" },
-                          { label: "Blue", value: "blue" },
-                          { label: "Purple", value: "purple" },
-                          { label: "Green", value: "green" },
-                          { label: "Amber", value: "amber" },
+                          {
+                            label: t("settings.theme.variants.default"),
+                            value: "default",
+                          },
+                          {
+                            label: t("settings.theme.variants.blue"),
+                            value: "blue",
+                          },
+                          {
+                            label: t("settings.theme.variants.purple"),
+                            value: "purple",
+                          },
+                          {
+                            label: t("settings.theme.variants.green"),
+                            value: "green",
+                          },
+                          {
+                            label: t("settings.theme.variants.amber"),
+                            value: "amber",
+                          },
                         ]}
                         fullWidth
                       />
@@ -690,17 +775,17 @@ export function SettingsModal({
             <Stack gap="xl">
               <div>
                 <Text size="xl" fw={600} mb="lg">
-                  Date & Time
+                  {t("settings.datetime.title")}
                 </Text>
                 <Text size="sm" c="dimmed" mb="xl">
-                  Configure how dates and times are displayed
+                  {t("settings.datetime.description")}
                 </Text>
 
                 <Stack gap="lg">
-                  {matchesSearch("Time Format 24 12 hour clock") && (
+                  {matchesSearch(t("settings.datetime.time_format")) && (
                     <div>
                       <Text size="sm" fw={500} mb={8}>
-                        Time Format
+                        {t("settings.datetime.time_format")}
                       </Text>
                       <Select
                         value={timeFormat}
@@ -709,15 +794,15 @@ export function SettingsModal({
                           { label: "24-Hour (13:34)", value: "24h" },
                           { label: "12-Hour (01:34 PM)", value: "12h" },
                         ]}
-                        placeholder="Select time format"
+                        placeholder={t("settings.datetime.time_format")}
                       />
                     </div>
                   )}
 
-                  {matchesSearch("Date Order MDY DMY YMD") && (
+                  {matchesSearch(t("settings.datetime.date_order")) && (
                     <div>
                       <Text size="sm" fw={500} mb={8}>
-                        Date Order
+                        {t("settings.datetime.date_order")}
                       </Text>
                       <Select
                         value={dateOrder}
@@ -727,18 +812,18 @@ export function SettingsModal({
                           { label: "Day/Month/Year (DMY)", value: "DMY" },
                           { label: "Year/Month/Day (YMD)", value: "YMD" },
                         ]}
-                        placeholder="Select date order"
+                        placeholder={t("settings.datetime.date_order")}
                       />
                       <Text size="xs" c="dimmed" mt={4}>
-                        Choose the order of year, month, and day
+                        {t("settings.datetime.date_separator_desc")}
                       </Text>
                     </div>
                   )}
 
-                  {matchesSearch("Date Separator slash hyphen dot") && (
+                  {matchesSearch(t("settings.datetime.date_separator")) && (
                     <div>
                       <Text size="sm" fw={500} mb={8}>
-                        Date Separator
+                        {t("settings.datetime.date_separator")}
                       </Text>
                       <Select
                         value={dateSeparator}
@@ -750,15 +835,15 @@ export function SettingsModal({
                           { label: "Hyphen (-)", value: "-" },
                           { label: "Dot (.)", value: "." },
                         ]}
-                        placeholder="Select separator"
+                        placeholder={t("settings.datetime.date_separator")}
                       />
                     </div>
                   )}
 
-                  {matchesSearch("timezone") && (
+                  {matchesSearch(t("settings.datetime.timezone")) && (
                     <div>
                       <Text size="sm" fw={500} mb={8}>
-                        Timezone
+                        {t("settings.datetime.timezone")}
                       </Text>
                       <Select
                         value={timezone}
@@ -836,13 +921,13 @@ export function SettingsModal({
                                 ...timezones,
                               ];
                         })()}
-                        placeholder="Select timezone"
+                        placeholder={t("settings.datetime.timezone")}
                         searchable
                       />
                     </div>
                   )}
 
-                  {matchesSearch("preview") && (
+                  {matchesSearch(t("settings.datetime.preview")) && (
                     <div
                       style={{
                         padding: 16,
@@ -851,7 +936,7 @@ export function SettingsModal({
                       }}
                     >
                       <Text size="sm" fw={500} mb={4}>
-                        Preview
+                        {t("settings.datetime.preview")}
                       </Text>
                       <Text size="sm">
                         {useClockFormatStore.getState().formatDate(new Date())}{" "}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,30 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+
+import en from "./locales/en.json";
+import ko from "./locales/ko.json";
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: {
+        translation: en,
+      },
+      ko: {
+        translation: ko,
+      },
+    },
+    fallbackLng: "en",
+    interpolation: {
+      escapeValue: false, // not needed for react as it escapes by default
+    },
+    detection: {
+      order: ["localStorage", "navigator"],
+      caches: ["localStorage"],
+    },
+  });
+
+export default i18n;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,170 @@
+{
+  "common": {
+    "search": "Search",
+    "settings": "Settings",
+    "help": "Help",
+    "close": "Close",
+    "cancel": "Cancel",
+    "save": "Save",
+    "delete": "Delete",
+    "edit": "Edit",
+    "create": "Create",
+    "back": "Back",
+    "loading": "Loading...",
+    "error": "Error",
+    "success": "Success",
+    "confirm": "Confirm",
+    "new_page": "New page"
+  },
+  "settings": {
+    "title": "Settings",
+    "search_placeholder": "Search settings...",
+    "search_active": "Search is active. If you don't see any matching sections, try a different keyword.",
+    "beta": "Beta",
+    "tabs": {
+      "appearance": "Appearance",
+      "theme": "Theme",
+      "datetime": "Date & Time",
+      "daily_notes": "Daily Notes",
+      "homepage": "Homepage",
+      "outliner": "Outliner",
+      "version_control": "Version Control",
+      "shortcuts": "Shortcuts",
+      "advanced": "Advanced",
+      "about": "About",
+      "language": "Language"
+    },
+    "appearance": {
+      "title": "Appearance",
+      "description": "Customize the look and feel of the editor",
+      "font_family": "Font Family",
+      "font_family_desc": "Choose the font used throughout the application",
+      "editor_font_size": "Editor Font Size",
+      "editor_font_size_desc": "Adjust the font size in the editor",
+      "editor_line_height": "Editor Line Height",
+      "editor_line_height_desc": "Adjust spacing between lines"
+    },
+    "theme": {
+      "title": "Theme",
+      "color_mode": "Color Mode",
+      "modes": {
+        "light": "Light",
+        "dark": "Dark",
+        "auto": "Auto"
+      },
+      "color_variant": "Color Variant",
+      "variants": {
+        "default": "Default",
+        "blue": "Blue",
+        "purple": "Purple",
+        "green": "Green",
+        "amber": "Amber"
+      }
+    },
+    "datetime": {
+      "title": "Date & Time",
+      "description": "Configure how dates and times are displayed",
+      "time_format": "Time Format",
+      "date_order": "Date Order",
+      "date_separator": "Date Separator",
+      "date_separator_desc": "Choose the order of year, month, and day",
+      "timezone": "Timezone",
+      "preview": "Preview"
+    },
+    "daily_notes": {
+      "title": "Daily Notes",
+      "description": "Configure automatic daily note creation",
+      "path": "Daily Notes Path",
+      "path_desc": "Path where daily notes will be created (e.g., 'Daily' or 'Notes/Daily')"
+    },
+    "homepage": {
+      "title": "Homepage",
+      "description": "Choose what to display when opening the app",
+      "type": "Homepage Type",
+      "type_desc": "Choose what to show when opening the app",
+      "types": {
+        "daily_note": "Today's Daily Note",
+        "index": "File Tree",
+        "custom_page": "Custom Page"
+      },
+      "custom_page": "Custom Homepage",
+      "custom_page_placeholder": "Select a page"
+    },
+    "outliner": {
+      "title": "Outliner",
+      "description": "Customize the block editor behavior",
+      "indent_guides": "Show indent guides",
+      "indent_guides_desc": "Display vertical lines to show indentation levels",
+      "auto_expand": "Auto-expand blocks",
+      "auto_expand_desc": "Automatically expand collapsed blocks when navigating",
+      "block_count": "Show block count",
+      "block_count_desc": "Display the number of child blocks for each parent",
+      "code_block_line_numbers": "Show code block line numbers",
+      "code_block_line_numbers_desc": "Display line numbers in code blocks",
+      "indent_size": "Indent Size"
+    },
+    "git": {
+      "title": "Version Control",
+      "description": "Git-based version control for your workspace",
+      "init_button": "Initialize Git Repository",
+      "why_git": "Why Use Git?",
+      "why_git_desc": "• Track all changes to your notes\n• Never lose work - full history available\n• Sync across devices with remote repositories\n• Collaborate with others using GitHub, GitLab, etc.",
+      "repo_location": "Repository Location",
+      "current_status": "Current Status",
+      "commit_changes": "Commit Changes",
+      "no_changes": "No Changes",
+      "refresh": "Refresh",
+      "uncommitted_changes": "⚠️ You have uncommitted changes",
+      "all_committed": "✓ All changes committed",
+      "auto_commit": "Auto-commit",
+      "enable_auto_commit": "Enable auto-commit",
+      "enable_auto_commit_desc": "Automatically commit changes at regular intervals",
+      "commit_interval": "Commit Interval",
+      "commit_interval_desc": "Automatic commits occur every {{interval}} minute(s)",
+      "remote_repo": "Remote Repository",
+      "add_remote": "Add Remote URL",
+      "push_pull_hint": "Push and pull buttons are available in the bottom-right corner"
+    },
+    "shortcuts": {
+      "title": "Keyboard Shortcuts",
+      "description": "View and customize keyboard shortcuts",
+      "command_palette": "Command Palette",
+      "search": "Search",
+      "toggle_index": "Toggle Index"
+    },
+    "advanced": {
+      "title": "Advanced",
+      "description": "Advanced settings and developer options",
+      "cache": "Cache",
+      "clear_cache": "Clear Cache",
+      "clear_cache_confirm": "Clear application cache?",
+      "updates": "Updates",
+      "auto_updates": "Automatic updates",
+      "auto_updates_desc": "Automatically download and install updates (coming soon)",
+      "check_startup": "Check for updates on startup",
+      "check_startup_desc": "Check for new versions when the app starts (coming soon)",
+      "beta_updates": "Beta updates",
+      "beta_updates_desc": "Receive beta versions with experimental features (coming soon)",
+      "check_updates_btn": "Check for Updates",
+      "current_version": "Current version: {{version}}",
+      "developer_options": "Developer Options",
+      "telemetry": "Anonymous telemetry",
+      "telemetry_desc": "Help improve Oxinot by sending anonymous usage data",
+      "danger_zone": "Danger Zone",
+      "reset_settings": "Reset All Settings",
+      "reset_settings_desc": "This will reset all settings to their default values and reload the application.",
+      "reset_confirm": "Are you sure you want to reset all settings? This action cannot be undone."
+    },
+    "about": {
+      "title": "About",
+      "updates_title": "Updates",
+      "updates_desc": "Oxinot is kept up-to-date automatically using Tauri Updater.",
+      "check_update_msg": "Update functionality will be enabled in a future release with Tauri Updater integration."
+    },
+    "language": {
+      "title": "Language",
+      "select": "Select Language",
+      "description": "Choose the language for the user interface"
+    }
+  }
+}

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1,0 +1,170 @@
+{
+  "common": {
+    "search": "검색",
+    "settings": "설정",
+    "help": "도움말",
+    "close": "닫기",
+    "cancel": "취소",
+    "save": "저장",
+    "delete": "삭제",
+    "edit": "편집",
+    "create": "생성",
+    "back": "뒤로",
+    "loading": "로딩 중...",
+    "error": "오류",
+    "success": "성공",
+    "confirm": "확인",
+    "new_page": "새 페이지"
+  },
+  "settings": {
+    "title": "설정",
+    "search_placeholder": "설정 검색...",
+    "search_active": "검색이 활성화되었습니다. 일치하는 섹션이 보이지 않으면 다른 키워드를 시도해보세요.",
+    "beta": "베타",
+    "tabs": {
+      "appearance": "모양",
+      "theme": "테마",
+      "datetime": "날짜 및 시간",
+      "daily_notes": "데일리 노트",
+      "homepage": "홈페이지",
+      "outliner": "아웃라이너",
+      "version_control": "버전 관리",
+      "shortcuts": "단축키",
+      "advanced": "고급",
+      "about": "정보",
+      "language": "언어"
+    },
+    "appearance": {
+      "title": "모양",
+      "description": "에디터의 모양과 느낌을 사용자 정의합니다",
+      "font_family": "글꼴",
+      "font_family_desc": "애플리케이션 전체에서 사용할 글꼴을 선택하세요",
+      "editor_font_size": "에디터 글꼴 크기",
+      "editor_font_size_desc": "에디터의 글꼴 크기를 조정합니다",
+      "editor_line_height": "에디터 줄 높이",
+      "editor_line_height_desc": "줄 간격을 조정합니다"
+    },
+    "theme": {
+      "title": "테마",
+      "color_mode": "색상 모드",
+      "modes": {
+        "light": "라이트",
+        "dark": "다크",
+        "auto": "자동"
+      },
+      "color_variant": "색상 변형",
+      "variants": {
+        "default": "기본",
+        "blue": "파랑",
+        "purple": "보라",
+        "green": "초록",
+        "amber": "호박색"
+      }
+    },
+    "datetime": {
+      "title": "날짜 및 시간",
+      "description": "날짜와 시간이 표시되는 방식을 설정합니다",
+      "time_format": "시간 형식",
+      "date_order": "날짜 순서",
+      "date_separator": "날짜 구분 기호",
+      "date_separator_desc": "년, 월, 일의 순서를 선택하세요",
+      "timezone": "시간대",
+      "preview": "미리보기"
+    },
+    "daily_notes": {
+      "title": "데일리 노트",
+      "description": "자동 데일리 노트 생성을 설정합니다",
+      "path": "데일리 노트 경로",
+      "path_desc": "데일리 노트가 생성될 경로 (예: 'Daily' 또는 'Notes/Daily')"
+    },
+    "homepage": {
+      "title": "홈페이지",
+      "description": "앱을 열 때 표시할 화면을 선택합니다",
+      "type": "홈페이지 유형",
+      "type_desc": "앱을 열 때 보여줄 내용을 선택하세요",
+      "types": {
+        "daily_note": "오늘의 데일리 노트",
+        "index": "파일 트리",
+        "custom_page": "사용자 정의 페이지"
+      },
+      "custom_page": "사용자 정의 홈페이지",
+      "custom_page_placeholder": "페이지 선택"
+    },
+    "outliner": {
+      "title": "아웃라이너",
+      "description": "블록 에디터 동작을 사용자 정의합니다",
+      "indent_guides": "들여쓰기 가이드 표시",
+      "indent_guides_desc": "들여쓰기 수준을 보여주는 수직선을 표시합니다",
+      "auto_expand": "블록 자동 펼치기",
+      "auto_expand_desc": "탐색 시 접힌 블록을 자동으로 펼칩니다",
+      "block_count": "블록 수 표시",
+      "block_count_desc": "각 부모 블록의 자식 블록 수를 표시합니다",
+      "code_block_line_numbers": "코드 블록 줄 번호 표시",
+      "code_block_line_numbers_desc": "코드 블록에 줄 번호를 표시합니다",
+      "indent_size": "들여쓰기 크기"
+    },
+    "git": {
+      "title": "버전 관리",
+      "description": "워크스페이스를 위한 Git 기반 버전 관리",
+      "init_button": "Git 저장소 초기화",
+      "why_git": "왜 Git을 사용하나요?",
+      "why_git_desc": "• 노트의 모든 변경 사항 추적\n• 작업 손실 방지 - 전체 기록 사용 가능\n• 원격 저장소로 여러 기기 간 동기화\n• GitHub, GitLab 등을 사용하여 다른 사람과 협업",
+      "repo_location": "저장소 위치",
+      "current_status": "현재 상태",
+      "commit_changes": "변경 사항 커밋",
+      "no_changes": "변경 사항 없음",
+      "refresh": "새로고침",
+      "uncommitted_changes": "⚠️ 커밋되지 않은 변경 사항이 있습니다",
+      "all_committed": "✓ 모든 변경 사항이 커밋되었습니다",
+      "auto_commit": "자동 커밋",
+      "enable_auto_commit": "자동 커밋 활성화",
+      "enable_auto_commit_desc": "일정한 간격으로 변경 사항을 자동으로 커밋합니다",
+      "commit_interval": "커밋 간격",
+      "commit_interval_desc": "자동 커밋은 {{interval}}분마다 발생합니다",
+      "remote_repo": "원격 저장소",
+      "add_remote": "원격 URL 추가",
+      "push_pull_hint": "푸시 및 풀 버튼은 오른쪽 하단 모서리에 있습니다"
+    },
+    "shortcuts": {
+      "title": "단축키",
+      "description": "키보드 단축키를 확인하고 사용자 정의합니다",
+      "command_palette": "명령 팔레트",
+      "search": "검색",
+      "toggle_index": "인덱스 토글"
+    },
+    "advanced": {
+      "title": "고급",
+      "description": "고급 설정 및 개발자 옵션",
+      "cache": "캐시",
+      "clear_cache": "캐시 지우기",
+      "clear_cache_confirm": "애플리케이션 캐시를 지우시겠습니까?",
+      "updates": "업데이트",
+      "auto_updates": "자동 업데이트",
+      "auto_updates_desc": "업데이트를 자동으로 다운로드하고 설치합니다 (준비 중)",
+      "check_startup": "시작 시 업데이트 확인",
+      "check_startup_desc": "앱이 시작될 때 새 버전을 확인합니다 (준비 중)",
+      "beta_updates": "베타 업데이트",
+      "beta_updates_desc": "실험적 기능이 포함된 베타 버전을 받습니다 (준비 중)",
+      "check_updates_btn": "업데이트 확인",
+      "current_version": "현재 버전: {{version}}",
+      "developer_options": "개발자 옵션",
+      "telemetry": "익명 원격 측정",
+      "telemetry_desc": "익명 사용 데이터를 보내 Oxinot 개선을 돕습니다",
+      "danger_zone": "위험 구역",
+      "reset_settings": "모든 설정 초기화",
+      "reset_settings_desc": "모든 설정을 기본값으로 초기화하고 애플리케이션을 다시 로드합니다.",
+      "reset_confirm": "모든 설정을 초기화하시겠습니까? 이 작업은 취소할 수 없습니다."
+    },
+    "about": {
+      "title": "정보",
+      "updates_title": "업데이트",
+      "updates_desc": "Oxinot은 Tauri Updater를 사용하여 자동으로 최신 상태를 유지합니다.",
+      "check_update_msg": "업데이트 기능은 Tauri Updater 통합과 함께 향후 릴리스에서 활성화될 예정입니다."
+    },
+    "language": {
+      "title": "언어",
+      "select": "언어 선택",
+      "description": "사용자 인터페이스의 언어를 선택하세요"
+    }
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import ReactDOM from "react-dom/client";
 import { ColorSchemeScript } from "@mantine/core";
+import "./i18n";
 import App from "./App";
 import "@mantine/core/styles.css";
 import "./index.css";


### PR DESCRIPTION
Implements basic i18n infrastructure and adds English/Korean support.

## Changes
- Installed `i18next` stack
- Added locale JSON files
- Initialized i18n in `main.tsx`
- Added Language selector in Settings
- Translated "Appearance" and "Theme" tabs in Settings

Closes #34