### PR TITLE
fix(ci): fix invalid syntax in auto-changeset workflow

### DIFF
--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -74,9 +74,7 @@ jobs:
         run: |
           PR_URL=$(gh pr create \
             --title "chore: auto-generate changeset" \
-            --body "Automatically generated changeset from merged PR.
-
-This PR will be auto-merged when CI passes." \
+            --body "Automatically generated changeset from merged PR. This PR will be auto-merged when CI passes." \
             --label changeset \
             --head "${{ steps.commit.outputs.branch_name }}")
 


### PR DESCRIPTION
Fixes a YAML syntax error in the auto-changeset workflow caused by a multiline string in the `gh pr create` command.

The error occurred at the line where `--head` was defined, likely due to improper indentation or parsing of the preceding blank line within the `--body` argument.