### PR TITLE
fix(file-deletion): persist file deletion to database

### DIFF
--- a/src/tauri-api.ts
+++ b/src/tauri-api.ts
@@ -50,6 +50,16 @@ export const tauriAPI = {
     return await invoke<boolean>("delete_path", { targetPath });
   },
 
+  deletePathWithDb: async (
+    workspacePath: string,
+    targetPath: string,
+  ): Promise<boolean> => {
+    return await invoke<boolean>("delete_path_with_db", {
+      workspacePath,
+      targetPath,
+    });
+  },
+
   renamePath: async (oldPath: string, newName: string): Promise<string> => {
     return await invoke<string>("rename_path", { oldPath, newName });
   },


### PR DESCRIPTION
Fix file deletion persistence issue where deleted files would reappear after app restart.

The problem was that when files were deleted via the file tree UI, only the filesystem was updated while the SQLite database records remained. During app restart and workspace sync, these orphaned database records would cause the files to reappear.

The solution adds a new backend command that deletes both the filesystem item AND the corresponding database records when a file is deleted from the file tree.

Changes:
- Add new `delete_path_with_db` Tauri command
- Update workspace store to use new command with database cleanup
- Properly cascade delete pages and blocks in database

Closes #83