### PR TITLE
fix(file-tree): refresh file tree after creating daily note hierarchy

### DIFF
--- a/src/hooks/useHomepage.ts
+++ b/src/hooks/useHomepage.ts
@@ -2,6 +2,7 @@ import { useAppSettingsStore } from "@/stores/appSettingsStore";
 import { useErrorStore } from "@/stores/errorStore";
 import { usePageStore } from "@/stores/pageStore";
 import { useViewStore } from "@/stores/viewStore";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 import {
   buildPageBreadcrumb,
   createPageHierarchy,
@@ -17,6 +18,7 @@ export const useHomepage = (): UseHomepageReturn => {
   const { loadPages, createPage, pageIds, pagesById, setCurrentPageId } =
     usePageStore();
   const { showIndex, openNote } = useViewStore();
+  const { loadDirectory, workspacePath } = useWorkspaceStore();
   const homepageType = useAppSettingsStore((state) => state.homepageType);
   const customHomepageId = useAppSettingsStore(
     (state) => state.customHomepageId,
@@ -72,6 +74,11 @@ export const useHomepage = (): UseHomepageReturn => {
             const loadedData = await loadPages();
             freshPageIds = loadedData.pageIds;
             freshPagesById = loadedData.pagesById;
+
+            // Refresh file tree after creating new page hierarchy
+            if (workspacePath) {
+              await loadDirectory(workspacePath);
+            }
 
             pageId = findPageByPath(fullPath, freshPageIds, freshPagesById);
             if (!pageId) {
@@ -136,6 +143,8 @@ export const useHomepage = (): UseHomepageReturn => {
       openNote,
       showIndex,
       addError,
+      workspacePath,
+      loadDirectory,
     ],
   );
 


### PR DESCRIPTION
Fix issue where Daily folder does not appear in file tree when daily note is opened on initial workspace load.

## Problem
When a workspace is loaded with daily note as the homepage, the daily note opens but the Daily folder and its file are not visible in the file tree. They only appear after manually navigating via calendar or breadcrumb.

## Root Cause
The page hierarchy is created when opening the daily note, but the file tree is not refreshed after creation. The file tree is only loaded during workspace initialization, before the daily note folder is created.

## Solution
After successfully creating the page hierarchy, refresh the file tree by calling `loadDirectory` to ensure newly created folders appear immediately in the file tree view.

## Changes
- Import `useWorkspaceStore` in `useHomepage` hook
- Call `loadDirectory(workspacePath)` after `createPageHierarchy` succeeds
- Adds `workspacePath` and `loadDirectory` to dependency array

Closes #37