### PR TITLE
chore(ci): fix changeset auto-generation race condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,17 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
 
-            # Create branch from latest origin/main to avoid out-of-date issues
+            # Fetch latest main and rebase to ensure we're up-to-date
             git fetch origin main
-            git checkout -b "$BRANCH_NAME" origin/main
+            git rebase origin/main
+
+            # Check if changeset branch already exists remotely and delete if it does
+            if git rev-parse --verify "origin/$BRANCH_NAME" >/dev/null 2>&1; then
+              echo "ℹ️ Changeset branch $BRANCH_NAME already exists, skipping..."
+              exit 0
+            fi
+
+            git checkout -b "$BRANCH_NAME"
             git add .changeset
             git commit -m "chore: auto-generate changeset"
             git push origin "$BRANCH_NAME"


### PR DESCRIPTION
Fix CI failure when multiple PRs are merged concurrently.

## Problem
When multiple PRs are merged simultaneously (e.g., #89 and others), the changeset auto-generation workflow fails with a non-fast-forward error:
- Changeset generation completes and creates a branch
- Before it can push, main is updated by another PR merge
- Push fails because the branch is out of date

## Solution
1. **Rebase on latest main**: Fetch and rebase on origin/main before creating the changeset branch to ensure we're up-to-date
2. **Skip if already exists**: Check if a changeset branch already exists and gracefully skip if it does, preventing duplicate changesets

## Changes
- Add `git fetch origin main && git rebase origin/main` before branch creation
- Add check to skip if changeset branch already exists remotely
- Prevents push failures in concurrent merge scenarios

This is a CI/workflow-only change with no impact on application code.