### PR TITLE
chore(ci): fix changeset workflow unstaged changes error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,9 @@ jobs:
 
             # Fetch latest main and rebase to ensure we're up-to-date
             git fetch origin main
+            git reset HEAD .changeset
             git rebase origin/main
+            git add .changeset
 
             # Check if changeset branch already exists remotely and delete if it does
             if git rev-parse --verify "origin/$BRANCH_NAME" >/dev/null 2>&1; then


### PR DESCRIPTION
Fix CI error when rebasing during changeset generation.

## Problem
Changeset auto-generation fails with error:
```
error: cannot rebase: You have unstaged changes.
error: additionally, your index contains uncommitted changes.
error: Please commit or stash them.
```

## Root Cause
1. `npm run changeset:auto` generates changeset file
2. `git add .changeset` stages the changes
3. `git rebase origin/main` fails because staged changes exist

Staged changes block rebase operations in git.

## Solution
- Reset staged .changeset changes before rebase
- Re-add .changeset after rebase succeeds
- Allows rebase to proceed cleanly without file conflicts

This is a follow-up to PR #91 which had the right idea but missed the staged changes issue.