### PR TITLE
fix: restore autocomplete keyboard navigation in link completion

### DIFF
--- a/src/editor/createEditor.ts
+++ b/src/editor/createEditor.ts
@@ -6,7 +6,7 @@ import {
   closeBracketsKeymap,
   closeCompletion,
   startCompletion,
-  acceptCompletion,
+  completionKeymap,
 } from "@codemirror/autocomplete";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
@@ -225,20 +225,6 @@ function createBasicExtensions(config: EditorConfig): Extension[] {
       // - Cmd/Ctrl+Alt+J: force-open completion
       // - Cmd/Ctrl+Alt+H: close completion
       {
-        key: "Enter",
-        run: (view) => {
-          // If autocomplete is active, accept the completion
-          // Otherwise, let the default Enter behavior handle it (insert newline)
-          return acceptCompletion(view);
-        },
-        preventDefault: true,
-      },
-
-      // Debug: allow inspecting the completion tooltip without it auto-closing while you click around.
-      // - Cmd/Ctrl+Alt+K: toggle "pin completion open" mode (stores flag on the DOM for quick access)
-      // - Cmd/Ctrl+Alt+J: force-open completion
-      // - Cmd/Ctrl+Alt+H: close completion
-      {
         key: "Mod-Alt-k",
         run: (view) => {
           const dom = view.dom as HTMLElement & {
@@ -272,6 +258,7 @@ function createBasicExtensions(config: EditorConfig): Extension[] {
       ...historyKeymap,
       ...closeBracketsKeymap,
       ...searchKeymap,
+      ...completionKeymap,
     ])
   );
 
@@ -809,7 +796,7 @@ function createUnifiedLinkAutocomplete(): Extension {
     // Keep exactly one autocompletion extension and combine sources here to avoid:
     // "Config merge conflict for field override"
     override: [wikiSource, blockSource],
-    defaultKeymap: false,
+    defaultKeymap: true,
     activateOnTyping: true,
 
     // Render the tooltip into a fixed-position portal so it can't be clipped by


### PR DESCRIPTION
Fixes issue where arrow keys and Enter don't work in autocomplete panels for wiki links and block references.

## Problem
After PR #113 was merged, autocomplete panels for link completion (wiki links, block references) became non-functional with keyboard navigation:
- Arrow keys didn't navigate suggestions
- Enter key didn't select items
- Users had to rely on mouse clicks only

## Root Cause
The PR disabled defaultKeymap to add a custom Enter handler, but this broke all the built-in keyboard navigation that CodeMirror provides.

## Solution
- Restore defaultKeymap: true to enable CodeMirror's default autocomplete keybindings
- Add completionKeymap to editor keybindings for proper key handling
- Remove the custom Enter handler (defaultKeymap handles it correctly)

## Testing
- Arrow keys now navigate autocomplete suggestions
- Enter selects the highlighted suggestion
- Escape closes the autocomplete panel
- Block-level rendering enforcement from PR #113 is still working