### PR TITLE
feat(metadata): implement block-level metadata system with key::value format

### DIFF
--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -58,6 +58,20 @@ CREATE TABLE IF NOT EXISTS block_refs (
 CREATE INDEX IF NOT EXISTS idx_refs_from ON block_refs(from_block_id);
 CREATE INDEX IF NOT EXISTS idx_refs_to ON block_refs(to_block_id);
 
+-- 블록 메타데이터 (key::value 형식)
+CREATE TABLE IF NOT EXISTS block_metadata (
+    id TEXT PRIMARY KEY,
+    block_id TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (block_id) REFERENCES blocks(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_block_metadata_block ON block_metadata(block_id);
+CREATE INDEX IF NOT EXISTS idx_block_metadata_key ON block_metadata(key);
+
 -- FTS: 링크 제안/검색을 위한 블록 검색 인덱스 (content + anchor id + path 캐시)
 -- NOTE: 이 테이블은 파생 데이터이며, 리빌드/리인덱싱 시 재생성될 수 있음.
 -- anchor_id는 마크다운 파일에만 숨겨 저장되는 "ID::<uuid>"에서 추출되어 blocks.id와 일치하도록 유지된다.
@@ -231,6 +245,17 @@ fn migrate_schema(conn: &rusqlite::Connection) -> Result<(), rusqlite::Error> {
         );
         CREATE INDEX IF NOT EXISTS idx_block_paths_page ON block_paths(page_id);
         CREATE INDEX IF NOT EXISTS idx_block_paths_text ON block_paths(path_text);
+
+        CREATE TABLE IF NOT EXISTS block_metadata (
+            id TEXT PRIMARY KEY,
+            block_id TEXT NOT NULL,
+            key TEXT NOT NULL,
+            value TEXT NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (block_id) REFERENCES blocks(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_block_metadata_block ON block_metadata(block_id);
+        CREATE INDEX IF NOT EXISTS idx_block_metadata_key ON block_metadata(key);
         "#,
     )?;
 

--- a/src-tauri/src/models/block.rs
+++ b/src-tauri/src/models/block.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -13,6 +14,8 @@ pub struct Block {
     pub language: Option<String>,
     pub created_at: String,
     pub updated_at: String,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,6 +62,7 @@ pub struct UpdateBlockRequest {
     pub is_collapsed: Option<bool>,
     pub block_type: Option<BlockType>,
     pub language: Option<String>,
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Overview
Implements flexible block-level metadata system using key::value format, consistent with existing ID::uuid pattern.

## Implementation Details

### Database
- Added `block_metadata` table with columns: id, block_id, key, value, created_at
- Indexes on block_id and key for efficient queries
- CASCADE DELETE when parent block is deleted

### Backend (Rust)
- **Markdown parsing**: Metadata lines (key::value) after ID markers are parsed into HashMap
- **Markdown serialization**: Metadata written after ID markers, sorted by key
- **Block commands**: All block operations (create, update, get) now load/save metadata
- **Helper functions**: `load_block_metadata`, `save_block_metadata`
- **Tests**: 7 comprehensive tests covering parsing, serialization, roundtrip, nested blocks, JSON values

### Frontend (TypeScript)
- Added `metadata?: Record<string, string>` field to BlockData interface
- Metadata supported in update_block command

## Supported Data Types
All values stored as strings, with support for:
- **Simple strings**: `title::Inception`
- **Numbers**: `year::2010`, `rating::5`
- **JSON objects**: `cast::{"actor": "role"}`
- **JSON arrays**: `tags::["action", "thriller"]`

## Example Usage

```markdown
- Movie review: Fight Club
  ID::550e8400-e29b-41d4-a716-446655440000
  title::Fight Club
  director::David Fincher
  year::1999
  rating::5
  cast::{"에드워드 노튼": "나레이터", "브래드 피트": "타일러 더든", "헬레나 본햄 카터": "말라 싱어"}
  - Incredible twist ending that changes everything
```

## Testing
- ✅ All 7 new tests passing
- ✅ Existing tests passing
- ✅ Lint passing
- ✅ Build successful

## Future Work (Separate Issues)
- [ ] UI for viewing/editing metadata (inline or panel)
- [ ] Metadata-based search and filtering
- [ ] Metadata templates

Closes #100