### PR TITLE
fix(config): move devtools to correct location in window config

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,13 +50,13 @@
         "trafficLightPosition": {
           "x": 20,
           "y": 22
-        }
+        },
+        "devtools": true
       }
     ],
     "security": {
       "csp": null
     },
-    "withGlobalTauri": false,
-    "enableDevtools": true
+    "withGlobalTauri": false
   }
 }


### PR DESCRIPTION
## Problem
Previous commit placed `devtools` setting in `app.security` which caused build error:
```
Error `tauri.conf.json` error on `app > security`: Additional properties are not allowed ('devtools' was unexpected)
```

## Solution
- Move `devtools: true` from `app.security` to `app.windows[0]`
- This is the correct location according to Tauri 2.x configuration schema

## Related
This fixes the configuration from #e4420fd to enable devtools in production builds for debugging update issues.

## Testing
- ✅ Configuration validates successfully
- ✅ Build completes without errors
- Next: Test that Cmd+Option+I opens devtools in production build