### PR TITLE
fix(tauri): enable devtools feature flag for release builds

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "2.5.3", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.9.5", features = [] }
+tauri = { version = "2.9.5", features = ["devtools"] }
 tauri-plugin-log = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"


### PR DESCRIPTION
## Problem
Developer tools (Cmd+Option+I / F12) were not opening in 0.3.1 release build despite having `devtools: true` in tauri.conf.json config.

## Root Cause
Tauri 2 requires the `devtools` feature flag to be enabled in Cargo.toml for web inspector to work in release builds.

## Solution
- Add 'devtools' feature to tauri dependency in src-tauri/Cargo.toml
- This allows the devtools configuration setting to take effect in production builds

## Testing
- ✅ Build completes successfully with new feature flag
- Once released and upgraded: Cmd+Option+I should open developer tools