### PR TITLE
fix(workflow): correct concurrency syntax in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: release
-  cancel_in_progress: false
+  cancel-in-progress: false
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
## Problem
GitHub Actions validation error in release.yml:
```
Unexpected value 'cancel_in_progress' on line 17
```

## Solution
Fix YAML syntax: `cancel_in_progress` → `cancel-in-progress` (with hyphen)

## Impact
- Fixes workflow validation error
- Release workflow can now run properly