### PR TITLE
fix: flush pending block updates on component unmount

### DIFF
--- a/src/hooks/useDebouncedBlockUpdate.ts
+++ b/src/hooks/useDebouncedBlockUpdate.ts
@@ -23,7 +23,7 @@ export function useDebouncedBlockUpdate(blockId: string) {
         }
       }, DEBOUNCE_MS);
     },
-    [blockId, updateBlockContent],
+    [blockId, updateBlockContent]
   );
 
   const flushUpdate = useCallback(() => {
@@ -39,11 +39,9 @@ export function useDebouncedBlockUpdate(blockId: string) {
   // Cleanup on unmount
   useEffect(() => {
     return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
+      flushUpdate();
     };
-  }, []);
+  }, [flushUpdate]);
 
   return { debouncedUpdate, flushUpdate };
 }


### PR DESCRIPTION
Prevent data loss when BlockEditor component unmounts while updates are pending.

Flushes debounced block updates on unmount to ensure all changes are persisted.