### PR TITLE
fix(editor): Ensure Space inserts during IME and completion

### DIFF
--- a/src/editor/createEditor.ts
+++ b/src/editor/createEditor.ts
@@ -140,6 +140,15 @@ function createBasicExtensions(config: EditorConfig): Extension[] {
     keymap.of([
       ...(config.keybindings ?? []),
 
+      // Force insert Space to bypass any blockers (completion keymap, IME artifacts, etc)
+      {
+        key: "Space",
+        run: (view) => {
+          view.dispatch(view.state.replaceSelection(" "));
+          return true;
+        },
+      },
+
       // Custom backspace handler for [[ ]], (( )), ![[  ]], !(( )) pairs
       {
         key: "Backspace",
@@ -800,7 +809,7 @@ function createUnifiedLinkAutocomplete(): Extension {
     // Keep exactly one autocompletion extension and combine sources here to avoid:
     // "Config merge conflict for field override"
     override: [wikiSource, blockSource],
-    defaultKeymap: true,
+    defaultKeymap: false, // Disable default keymap to prevent Space from closing completion
     activateOnTyping: true,
 
     // Render the tooltip into a fixed-position portal so it can't be clipped by

--- a/src/outliner/BlockComponent.tsx
+++ b/src/outliner/BlockComponent.tsx
@@ -319,6 +319,11 @@ export const BlockComponent: React.FC<BlockComponentProps> = memo(
 
       // Intercept Enter key during or after IME composition at DOM level (capture phase)
       const handleKeyDown = (e: KeyboardEvent) => {
+        // Clear IME flag on Space key - ensures normal text input after composition
+        if (e.key === " ") {
+          imeStateRef.current.lastInputWasComposition = false;
+        }
+
         // Determine if this Enter is IME-related by checking:
         // 1. Active composition (e.g., Japanese IME candidate selection)
         // 2. Last input was composition-based (e.g., Korean IME finished composition)


### PR DESCRIPTION
Fixes an issue where Space key input is blocked after typing Korean characters.

This is a workaround that:
1. Explicitly handles Space key in CodeMirror keymap to force insertion
2. Resets IME composition state in BlockComponent when Space is pressed