### PR TITLE
fix(page_sync): implement atomic writes for data integrity

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "oxinot"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "log",


### PR DESCRIPTION
Implement atomic write pattern to prevent data corruption from interrupted writes.

## Changes

- Replace non-atomic std::fs::write with atomic write pattern
- Write to temporary file (.filename.md.tmp) first
- Sync to disk using file.sync_all()
- Atomically rename temp file to target filename
- Cleanup temp file if rename fails

## Why This Matters

Previously, if the app crashed during a file write operation, the markdown file could be corrupted (truncated or partially written), causing data loss.

With atomic writes, the file is either fully updated or not touched at all, ensuring data integrity.

Closes #201