### PR TITLE
feat(delete): implement soft delete pattern for data consistency

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "oxinot"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "log",

--- a/src-tauri/src/commands/page.rs
+++ b/src-tauri/src/commands/page.rs
@@ -367,10 +367,10 @@ fn check_and_convert_to_file(
         return Ok(());
     }
 
-    // Count children
+    // Count children (exclude soft-deleted)
     let child_count: i32 = conn
         .query_row(
-            "SELECT COUNT(*) FROM pages WHERE parent_id = ?",
+            "SELECT COUNT(*) FROM pages WHERE parent_id = ? AND is_deleted = 0",
             [page_id],
             |row| row.get(0),
         )

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -213,7 +213,7 @@ pub fn sync_workspace(workspace_path: String) -> Result<MigrationResult, String>
     // If found, we must wipe DB and force full reindex
     {
         let mut stmt = conn
-            .prepare("SELECT COUNT(*) FROM pages WHERE file_path IS NOT NULL AND (file_path LIKE '/%' OR file_path LIKE '%:\\%')")
+            .prepare("SELECT COUNT(*) FROM pages WHERE file_path IS NOT NULL AND (file_path LIKE '/%' OR file_path LIKE '%:\\%') AND is_deleted = 0")
             .map_err(|e| e.to_string())?;
 
         let has_absolute: i32 = stmt
@@ -239,7 +239,9 @@ pub fn sync_workspace(workspace_path: String) -> Result<MigrationResult, String>
         std::collections::HashMap::new();
     {
         let mut stmt = conn
-            .prepare("SELECT id, file_path FROM pages WHERE file_path IS NOT NULL")
+            .prepare(
+                "SELECT id, file_path FROM pages WHERE file_path IS NOT NULL AND is_deleted = 0",
+            )
             .map_err(|e| e.to_string())?;
 
         let pages = stmt

--- a/src-tauri/src/services/page_path_service.rs
+++ b/src-tauri/src/services/page_path_service.rs
@@ -23,8 +23,10 @@ pub fn remove_page_path(conn: &Connection, page_id: &str) -> Result<(), rusqlite
 }
 
 pub fn migrate_populate_page_paths(conn: &Connection) -> Result<(), rusqlite::Error> {
-    // Populate page_paths table from existing pages
-    let mut stmt = conn.prepare("SELECT id, file_path FROM pages WHERE file_path IS NOT NULL")?;
+    // Populate page_paths table from existing pages (exclude soft-deleted)
+    let mut stmt = conn.prepare(
+        "SELECT id, file_path FROM pages WHERE file_path IS NOT NULL AND is_deleted = 0",
+    )?;
 
     let pages: Vec<(String, String)> = stmt
         .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?


### PR DESCRIPTION
Implement soft delete mechanism to ensure data consistency between database and filesystem.

## Problem

Previous implementation deleted from DB first. If filesystem deletion fails, the DB is already updated, leaving the workspace in an inconsistent state ('ghost' deletion).

## Solution

Implement three-phase soft delete:
1. Mark pages as 'deleting' in DB (is_deleted = 1)
2. Delete from filesystem
3. On success: completely remove from DB
4. On failure: revert is_deleted flag for retry on app restart

## Changes

- Add is_deleted column to pages table with automatic migration
- Update delete_path_with_db() to use soft delete pattern
- Update all page queries to filter out soft-deleted pages:
  - sync_workspace queries
  - check_and_convert_to_file
  - migrate_populate_page_paths
  - All other SELECT queries from pages table

## Benefits

- Prevents data loss from interrupted deletes
- Allows retry on app restart
- Maintains DB/FS consistency at all times
- Graceful handling of permissions errors

Closes #203