### PR TITLE
fix(git): add path validation to all git commands

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "oxinot"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "log",

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -1,3 +1,4 @@
+use crate::utils::path::validate_no_path_traversal;
 use std::path::Path;
 use std::process::Command;
 use tauri::command;
@@ -21,6 +22,7 @@ pub struct GitCommitResult {
 /// Initialize a git repository in the workspace
 #[command]
 pub fn git_init(workspace_path: String) -> Result<bool, String> {
+    validate_no_path_traversal(&workspace_path, "workspace_path")?;
     let path = Path::new(&workspace_path);
 
     if !path.exists() {
@@ -71,6 +73,7 @@ pub fn git_init(workspace_path: String) -> Result<bool, String> {
 /// Check if workspace is a git repository
 #[command]
 pub fn git_is_repo(workspace_path: String) -> Result<bool, String> {
+    validate_no_path_traversal(&workspace_path, "workspace_path")?;
     let path = Path::new(&workspace_path);
     let git_dir = path.join(".git");
     Ok(git_dir.exists() && git_dir.is_dir())
@@ -79,6 +82,7 @@ pub fn git_is_repo(workspace_path: String) -> Result<bool, String> {
 /// Get git status of the workspace
 #[command]
 pub fn git_status(workspace_path: String) -> Result<GitStatus, String> {
+    validate_no_path_traversal(&workspace_path, "workspace_path")?;
     let path = Path::new(&workspace_path);
 
     // Check if git repo
@@ -148,6 +152,7 @@ fn get_remote_url_internal(path: &Path) -> Option<String> {
 /// Get git remote URL
 #[command]
 pub fn git_get_remote_url(workspace_path: String) -> Result<Option<String>, String> {
+    validate_no_path_traversal(&workspace_path, "workspace_path")?;
     let path = Path::new(&workspace_path);
 
     if !path.join(".git").exists() {
@@ -160,6 +165,7 @@ pub fn git_get_remote_url(workspace_path: String) -> Result<Option<String>, Stri
 /// Set git remote URL
 #[command]
 pub fn git_set_remote_url(workspace_path: String, url: String) -> Result<String, String> {
+    validate_no_path_traversal(&workspace_path, "workspace_path")?;
     let path = Path::new(&workspace_path);
 
     if !path.join(".git").exists() {
@@ -198,6 +204,7 @@ pub fn git_set_remote_url(workspace_path: String, url: String) -> Result<String,
 /// Remove git remote
 #[command]
 pub fn git_remove_remote(workspace_path: String) -> Result<String, String> {
+    validate_no_path_traversal(&workspace_path, "workspace_path")?;
     let path = Path::new(&workspace_path);
 
     if !path.join(".git").exists() {
@@ -223,10 +230,8 @@ pub fn git_remove_remote(workspace_path: String) -> Result<String, String> {
 
 /// Commit changes with a message
 #[command]
-pub fn git_commit(
-    workspace_path: String,
-    message: String,
-) -> Result<GitCommitResult, String> {
+pub fn git_commit(workspace_path: String, message: String) -> Result<GitCommitResult, String> {
+    validate_no_path_traversal(&workspace_path, "workspace_path")?;
     let path = Path::new(&workspace_path);
 
     // Check if git repo
@@ -306,6 +311,7 @@ pub fn git_commit(
 /// Push changes to remote
 #[command]
 pub fn git_push(workspace_path: String) -> Result<String, String> {
+    validate_no_path_traversal(&workspace_path, "workspace_path")?;
     let path = Path::new(&workspace_path);
 
     if !path.join(".git").exists() {
@@ -331,6 +337,7 @@ pub fn git_push(workspace_path: String) -> Result<String, String> {
 /// Pull changes from remote
 #[command]
 pub fn git_pull(workspace_path: String) -> Result<String, String> {
+    validate_no_path_traversal(&workspace_path, "workspace_path")?;
     let path = Path::new(&workspace_path);
 
     if !path.join(".git").exists() {
@@ -356,6 +363,7 @@ pub fn git_pull(workspace_path: String) -> Result<String, String> {
 /// Get git log (recent commits)
 #[command]
 pub fn git_log(workspace_path: String, limit: Option<usize>) -> Result<Vec<String>, String> {
+    validate_no_path_traversal(&workspace_path, "workspace_path")?;
     let path = Path::new(&workspace_path);
 
     if !path.join(".git").exists() {


### PR DESCRIPTION
Add path traversal protection to all git command handlers.

## Problem

Unlike other filesystem commands in lib.rs, git.rs commands don't validate workspace_path for path traversal attacks.

While likely driven by UI controls, this exposes a potential security vulnerability if workspace_path is manipulated.

## Solution

Add validate_no_path_traversal() to all git commands:
- git_init
- git_is_repo
- git_status
- git_get_remote_url
- git_set_remote_url
- git_remove_remote
- git_commit
- git_push
- git_pull
- git_log

## Security Impact

Prevents path traversal attacks that could:
- Access files outside workspace
- Initialize unauthorized repos
- Access sensitive repository information
- Bypass intended security boundaries

Closes #205