### PR TITLE
refactor(error): add foundation for standardized error handling

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "oxinot"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "log",

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -8,6 +8,7 @@
 //! # Error Conversion
 //! Errors automatically convert to String for Tauri command responses via Display trait.
 
+use rusqlite;
 use std::io;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -121,6 +122,13 @@ impl OxinotError {
 
 /// Result type alias for Oxinot operations.
 pub type Result<T> = std::result::Result<T, OxinotError>;
+
+/// Convert rusqlite errors to OxinotError
+impl From<rusqlite::Error> for OxinotError {
+    fn from(err: rusqlite::Error) -> Self {
+        OxinotError::Database(err.to_string())
+    }
+}
 
 /// Trait for converting errors to Tauri command responses.
 /// Automatically implements Display which converts to String for Tauri.


### PR DESCRIPTION
Add foundation for standardized error handling across the codebase.

## Problem

Currently, many functions use `.map_err(|e| e.to_string())` which loses error context and makes debugging harder.

## Solution - Phase 1

This PR adds the foundation for standardized error handling:

1. Add `rusqlite::Error` to `OxinotError` conversion
2. Enables future migration from `Result<T, String>` to `Result<T>` pattern
3. Maintains Tauri compatibility via existing `From<OxinotError> for String`

## Next Steps (Tracked in #207)

Full refactoring will involve:
1. Update function signatures throughout codebase
2. Replace string conversions with proper error types  
3. Preserve error context for logging and debugging
4. Add structured error responses for frontend

This is a phased approach to avoid massive refactoring in one PR.

Closes #207