### PR TITLE
i18n: Extract and translate hardcoded strings in SettingsModal

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -301,11 +301,11 @@ export function SettingsModal({
         t("settings.appearance.font_family").toLowerCase(),
         t("settings.appearance.editor_font_size").toLowerCase(),
         t("settings.appearance.editor_line_height").toLowerCase(),
-        "typography",
+        t("common.search_keywords.typography").toLowerCase(),
         "inter",
         "system",
         "roboto",
-        "monospace",
+        t("common.search_keywords.monospace").toLowerCase(),
         "preview",
       ],
       theme: [
@@ -356,25 +356,25 @@ export function SettingsModal({
         t("settings.outliner.block_count").toLowerCase(),
         t("settings.outliner.code_block_line_numbers").toLowerCase(),
         t("settings.outliner.indent_size").toLowerCase(),
-        "blocks",
-        "code block",
+        t("common.search_keywords.blocks").toLowerCase(),
+        t("common.search_keywords.code_block").toLowerCase(),
         "line numbers",
       ],
       git: [
         t("settings.git.title").toLowerCase(),
-        "git",
-        "repository",
-        "commit",
+        t("common.search_keywords.git").toLowerCase(),
+        t("common.search_keywords.repository").toLowerCase(),
+        t("common.search_keywords.commit").toLowerCase(),
         t("settings.git.auto_commit").toLowerCase(),
         t("settings.git.remote_repo").toLowerCase(),
-        "push",
-        "pull",
+        t("common.search_keywords.push").toLowerCase(),
+        t("common.search_keywords.pull").toLowerCase(),
         "interval",
         "status",
       ],
       shortcuts: [
         t("settings.shortcuts.title").toLowerCase(),
-        "hotkey",
+        t("common.search_keywords.hotkey").toLowerCase(),
         t("settings.shortcuts.command_palette").toLowerCase(),
         t("settings.shortcuts.search").toLowerCase(),
         t("settings.shortcuts.toggle_index").toLowerCase(),
@@ -390,8 +390,8 @@ export function SettingsModal({
         "danger",
       ],
       about: [
-        "version",
-        "changelog",
+        t("common.search_keywords.version").toLowerCase(),
+        t("common.search_keywords.changelog").toLowerCase(),
         "oxinot",
         "info",
         "update",
@@ -399,9 +399,9 @@ export function SettingsModal({
       ],
       language: [
         t("settings.language.title").toLowerCase(),
-        "english",
-        "korean",
-        "locale",
+        t("common.search_keywords.english").toLowerCase(),
+        t("common.search_keywords.korean").toLowerCase(),
+        t("common.search_keywords.locale").toLowerCase(),
       ],
     };
 
@@ -1633,17 +1633,17 @@ export function SettingsModal({
                       </Text>
                       {useUpdaterStore.getState().status === "checking" && (
                         <Badge color="blue" variant="light">
-                          Checking...
+                          {t("settings.about.checking_status")}
                         </Badge>
                       )}
                       {useUpdaterStore.getState().status === "available" && (
                         <Badge color="green" variant="light">
-                          Update Available
+                          {t("settings.about.update_available")}
                         </Badge>
                       )}
                       {useUpdaterStore.getState().status === "uptodate" && (
                         <Badge color="gray" variant="light">
-                          Latest Version
+                          {t("settings.about.latest_version")}
                         </Badge>
                       )}
                     </Group>
@@ -1666,7 +1666,7 @@ export function SettingsModal({
                       if (status === "checking") {
                         return (
                           <Text size="sm" c="dimmed">
-                            Checking for updates...
+                            {t("settings.about.checking_for_updates")}
                           </Text>
                         );
                       }
@@ -1675,7 +1675,7 @@ export function SettingsModal({
                         return (
                           <Stack gap="xs">
                             <Text size="sm" c="dimmed">
-                              Oxinot is up to date.
+                              {t("settings.about.up_to_date")}
                             </Text>
                             <Group>
                               <Button
@@ -1684,7 +1684,7 @@ export function SettingsModal({
                                 onClick={() => checkForUpdates(false)}
                                 leftSection={<IconDownload size={16} />}
                               >
-                                Check Again
+                                {t("settings.about.check_again")}
                               </Button>
                             </Group>
                           </Stack>
@@ -1695,11 +1695,9 @@ export function SettingsModal({
                         return (
                           <Stack gap="md">
                             <Text size="sm">
-                              A new version{" "}
-                              <Text span fw={700}>
-                                {version}
-                              </Text>{" "}
-                              is available.
+                              {t("settings.about.new_version_available", {
+                                version: version,
+                              })}
                             </Text>
                             {body && (
                               <div
@@ -1726,7 +1724,7 @@ export function SettingsModal({
                                 onClick={installUpdate}
                                 leftSection={<IconDownload size={16} />}
                               >
-                                Update Now
+                                {t("settings.about.update_now")}
                               </Button>
                             </Group>
                           </Stack>
@@ -1737,7 +1735,9 @@ export function SettingsModal({
                         return (
                           <Stack gap="xs">
                             <Group justify="space-between">
-                              <Text size="sm">Downloading update...</Text>
+                              <Text size="sm">
+                                {t("settings.about.downloading_update")}
+                              </Text>
                               <Text size="xs" c="dimmed">
                                 {Math.round(progress)}%
                               </Text>
@@ -1751,10 +1751,10 @@ export function SettingsModal({
                         return (
                           <Stack gap="xs">
                             <Text size="sm" c="green">
-                              Update downloaded successfully.
+                              {t("settings.about.download_success")}
                             </Text>
                             <Text size="xs" c="dimmed">
-                              The application will restart automatically.
+                              {t("settings.about.auto_restart")}
                             </Text>
                           </Stack>
                         );
@@ -1764,7 +1764,7 @@ export function SettingsModal({
                         return (
                           <Stack gap="xs">
                             <Text size="sm" c="red">
-                              Error checking for updates:
+                              {t("settings.about.update_error")}
                             </Text>
                             <Text size="xs" c="dimmed">
                               {error}
@@ -1775,7 +1775,7 @@ export function SettingsModal({
                               color="red"
                               onClick={() => checkForUpdates(false)}
                             >
-                              Try Again
+                              {t("settings.about.check_again")}
                             </Button>
                           </Stack>
                         );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -29,6 +29,25 @@
       "edit_metadata": "Edit metadata",
       "copy": "Copy",
       "cut": "Cut"
+    },
+    "search_keywords": {
+      "typography": "Typography",
+      "font": "Font",
+      "monospace": "Monospace",
+      "blocks": "Blocks",
+      "code_block": "Code Block",
+      "indent": "Indent",
+      "repository": "Repository",
+      "git": "Git",
+      "commit": "Commit",
+      "push": "Push",
+      "pull": "Pull",
+      "version": "Version",
+      "changelog": "Changelog",
+      "hotkey": "Hotkey",
+      "locale": "Locale",
+      "english": "English",
+      "korean": "Korean"
     }
   },
   "navigation": {
@@ -203,7 +222,19 @@
       "updates_title": "Updates",
       "updates_desc": "Oxinot is kept up-to-date automatically using Tauri Updater.",
       "check_update_msg": "Check for updates now.",
-      "check_updates_btn": "Check for Updates"
+      "check_updates_btn": "Check for Updates",
+      "checking_status": "Checking...",
+      "update_available": "Update Available",
+      "latest_version": "Latest Version",
+      "checking_for_updates": "Checking for updates...",
+      "up_to_date": "Oxinot is up to date.",
+      "check_again": "Check Again",
+      "new_version_available": "A new version {{version}} is available.",
+      "downloading_update": "Downloading update...",
+      "download_success": "Update downloaded successfully.",
+      "auto_restart": "The application will restart automatically.",
+      "update_error": "Error checking for updates:",
+      "update_now": "Update Now"
     },
     "language": {
       "title": "Language",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -29,6 +29,25 @@
       "edit_metadata": "메타데이터 편집",
       "copy": "복사",
       "cut": "잘라내기"
+    },
+    "search_keywords": {
+      "typography": "타이포그래피",
+      "font": "글꼴",
+      "monospace": "고정폭",
+      "blocks": "블록",
+      "code_block": "코드 블록",
+      "indent": "들여쓰기",
+      "repository": "저장소",
+      "git": "Git",
+      "commit": "커밋",
+      "push": "푸시",
+      "pull": "풀",
+      "version": "버전",
+      "changelog": "변경 로그",
+      "hotkey": "단축키",
+      "locale": "로케일",
+      "english": "영어",
+      "korean": "한국어"
     }
   },
   "navigation": {
@@ -203,7 +222,19 @@
       "updates_title": "업데이트",
       "updates_desc": "Oxinot은 Tauri Updater를 사용하여 자동으로 최신 상태를 유지합니다.",
       "check_update_msg": "지금 업데이트를 확인합니다.",
-      "check_updates_btn": "업데이트 확인"
+      "check_updates_btn": "업데이트 확인",
+      "checking_status": "확인 중...",
+      "update_available": "업데이트 사용 가능",
+      "latest_version": "최신 버전",
+      "checking_for_updates": "업데이트를 확인 중입니다...",
+      "up_to_date": "Oxinot이 최신 상태입니다.",
+      "check_again": "다시 확인",
+      "new_version_available": "새 버전 {{version}}을 사용할 수 있습니다.",
+      "downloading_update": "업데이트를 다운로드 중입니다...",
+      "download_success": "업데이트를 성공적으로 다운로드했습니다.",
+      "auto_restart": "애플리케이션이 자동으로 다시 시작됩니다.",
+      "update_error": "업데이트 확인 중 오류 발생:",
+      "update_now": "지금 업데이트"
     },
     "language": {
       "title": "언어",


### PR DESCRIPTION
Extract hardcoded English strings from SettingsModal and add i18n translations.

Changes:
- Extract update status messages (checking, available, downloaded, error)
- Extract update button labels  
- Convert hardcoded search keywords to i18n keys
- Add translations for both en and ko locales
- Add search_keywords section to common i18n

Closes #220