### PR TITLE
chore(settings): remove MetadataDisplayStyle legacy setting

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -203,12 +203,6 @@ export function SettingsModal({
   const setIndentSize = useOutlinerSettingsStore(
     (state) => state.setIndentSize
   );
-  const metadataDisplayStyle = useOutlinerSettingsStore(
-    (state) => state.metadataDisplayStyle
-  );
-  const setMetadataDisplayStyle = useOutlinerSettingsStore(
-    (state) => state.setMetadataDisplayStyle
-  );
 
   // Git
   const isGitRepo = useGitStore((state) => state.isRepo);
@@ -610,10 +604,6 @@ export function SettingsModal({
               setShowCodeBlockLineNumbers={setShowCodeBlockLineNumbers}
               indentSize={indentSize}
               setIndentSize={setIndentSize}
-              metadataDisplayStyle={metadataDisplayStyle}
-              setMetadataDisplayStyle={(style) =>
-                setMetadataDisplayStyle(style as "property" | "box")
-              }
             />
           </Tabs.Panel>
 

--- a/src/components/settings/OutlinerSettings.tsx
+++ b/src/components/settings/OutlinerSettings.tsx
@@ -1,10 +1,4 @@
-import {
-  NumberInput,
-  SegmentedControl,
-  Stack,
-  Switch,
-  Text,
-} from "@mantine/core";
+import { NumberInput, Stack, Switch, Text } from "@mantine/core";
 import { useTranslation } from "react-i18next";
 import type { OutlinerSettingsProps } from "./types";
 
@@ -20,8 +14,6 @@ export function OutlinerSettings({
   setShowCodeBlockLineNumbers,
   indentSize,
   setIndentSize,
-  metadataDisplayStyle,
-  setMetadataDisplayStyle,
 }: OutlinerSettingsProps) {
   const { t } = useTranslation();
 
@@ -93,28 +85,6 @@ export function OutlinerSettings({
                 min={12}
                 max={48}
                 step={2}
-              />
-            </div>
-          )}
-
-          {matchesSearch("metadata display style") && (
-            <div>
-              <Text size="sm" fw={500} mb={8}>
-                Metadata Display Style
-              </Text>
-              <Text size="xs" c="dimmed" mb={8}>
-                Choose how to display block metadata (key::value)
-              </Text>
-              <SegmentedControl
-                value={metadataDisplayStyle}
-                onChange={(value) => {
-                  if (value)
-                    setMetadataDisplayStyle(value as "property" | "box");
-                }}
-                data={[
-                  { label: "▸ Property Block", value: "property" },
-                  { label: "□ Gray Box", value: "box" },
-                ]}
               />
             </div>
           )}

--- a/src/components/settings/types.ts
+++ b/src/components/settings/types.ts
@@ -63,8 +63,6 @@ export interface OutlinerSettingsProps extends SettingsComponentProps {
   setShowCodeBlockLineNumbers: (value: boolean) => void;
   indentSize: number;
   setIndentSize: (size: number) => void;
-  metadataDisplayStyle: string;
-  setMetadataDisplayStyle: (style: "property" | "box") => void;
 }
 
 export interface GitCommitResult {

--- a/src/stores/outlinerSettingsStore.ts
+++ b/src/stores/outlinerSettingsStore.ts
@@ -91,7 +91,6 @@ interface OutlinerSettings {
   showBlockCount: boolean;
   showCodeBlockLineNumbers: boolean;
   indentSize: number;
-  metadataDisplayStyle: "property" | "box";
 }
 
 interface OutlinerSettingsStore extends OutlinerSettings {
@@ -103,7 +102,6 @@ interface OutlinerSettingsStore extends OutlinerSettings {
   setShowBlockCount: (value: boolean) => void;
   setShowCodeBlockLineNumbers: (value: boolean) => void;
   setIndentSize: (size: number) => void;
-  setMetadataDisplayStyle: (style: "property" | "box") => void;
 }
 
 export const useOutlinerSettingsStore =
@@ -117,7 +115,6 @@ export const useOutlinerSettingsStore =
         showBlockCount: false,
         showCodeBlockLineNumbers: true,
         indentSize: 24,
-        metadataDisplayStyle: "property",
 
         // Actions
         toggleIndentGuides: () =>
@@ -135,9 +132,6 @@ export const useOutlinerSettingsStore =
           set({ showCodeBlockLineNumbers: value }),
 
         setIndentSize: (size: number) => set({ indentSize: size }),
-
-        setMetadataDisplayStyle: (style: "property" | "box") =>
-          set({ metadataDisplayStyle: style }),
 
         setFontFamily: (font: FontFamily) => {
           set({ fontFamily: font });


### PR DESCRIPTION
## Description
Remove the legacy MetadataDisplayStyle setting from the Outliner settings tab as it is no longer actively used or needed.

## Changes
- Remove metadataDisplayStyle state and action from outlinerSettingsStore
- Remove metadata display style UI section from OutlinerSettings component
- Remove SegmentedControl import (no longer needed)
- Update OutlinerSettingsProps interface
- Clean up SettingsModal component state

## Impact
- Simplifies settings UI by removing unused legacy functionality
- Reduces code complexity and maintenance burden
- No user-facing impact as this was legacy functionality

## Testing
- Settings modal opens correctly
- No errors in browser console
- Build completes successfully

Closes #158