### PR TITLE
feat(ci): include changelog in release body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,33 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Extract Changelog
+        id: changelog
+        shell: bash
+        run: |
+          VERSION="${{ steps.tag.outputs.name }}"
+          VERSION=${VERSION#v}
+
+          echo "Extracting changelog for version $VERSION"
+
+          # Extract section from CHANGELOG.md
+          awk -v ver="$VERSION" '
+            /^## / {
+              if (p) { exit }
+              if ($2 == ver) { p=1; next }
+            }
+            p
+          ' CHANGELOG.md > RELEASE_BODY.md
+
+          # If file is empty, use default message
+          if [ ! -s RELEASE_BODY.md ]; then
+            echo "See the assets to download this version and check the release notes." > RELEASE_BODY.md
+          fi
+
+          echo "RELEASE_BODY<<EOF" >> $GITHUB_ENV
+          cat RELEASE_BODY.md >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
       - name: Import Code-Signing Certificates for macOS
         uses: Apple-Actions/import-codesign-certs@v2
         with:
@@ -206,6 +233,6 @@ jobs:
         with:
           tagName: ${{ steps.tag.outputs.name }}
           releaseName: "Oxinot ${{ steps.tag.outputs.name }}"
-          releaseBody: "See the assets to download this version and check the release notes."
+          releaseBody: ${{ env.RELEASE_BODY }}
           releaseDraft: false
           prerelease: false


### PR DESCRIPTION
## Description
Updates the release workflow to automatically extract the changelog for the current version from `CHANGELOG.md` and include it in the GitHub Release body.

## Changes
- Added a step to `release.yml` to parse `CHANGELOG.md` using `awk` based on the version tag.
- Configured the `tauri-action` step to use the extracted changelog as the release body.

## Benefits
- Users can see what changed directly in the GitHub Release page.
- Automation removes the need for manual copy-pasting.