### PR TITLE
refactor(ui): replace hardcoded hex colors with CSS variables

### DIFF
--- a/src/components/CalendarDropdown.tsx
+++ b/src/components/CalendarDropdown.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Box, Button, Stack, Text, useComputedColorScheme } from "@mantine/core";
+import { ActionIcon, Box, Button, Stack, Text } from "@mantine/core";
 import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
 import { useState } from "react";
 import { useAppSettingsStore } from "../stores/appSettingsStore";
@@ -10,8 +10,6 @@ interface CalendarDropdownProps {
 }
 
 export function CalendarDropdown({ onClose }: CalendarDropdownProps) {
-  const computedColorScheme = useComputedColorScheme("light");
-  const isDark = computedColorScheme === "dark";
   const [currentDate, setCurrentDate] = useState(new Date());
   const pagesById = usePageStore((state) => state.pagesById);
   const pageIds = usePageStore((state) => state.pageIds);
@@ -274,28 +272,22 @@ export function CalendarDropdown({ onClose }: CalendarDropdownProps) {
             cursor: "pointer",
             borderRadius: "4px",
             border: isToday
-              ? `2px solid ${isDark ? "#4dabf7" : "#228be6"}`
+              ? "2px solid var(--color-accent)"
               : "2px solid transparent",
             backgroundColor: hasNote
-              ? isDark
-                ? "rgba(74, 171, 247, 0.15)"
-                : "rgba(34, 139, 230, 0.1)"
+              ? "var(--color-interactive-selected)"
               : "transparent",
             transition: "all 0.15s ease",
             fontWeight: hasNote ? 600 : 400,
-            color: isDark ? "#c1c2c5" : "#495057",
+            color: "var(--color-text-secondary)",
             fontSize: "13px",
           }}
           onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor = isDark
-              ? "rgba(255, 255, 255, 0.08)"
-              : "rgba(0, 0, 0, 0.05)";
+            e.currentTarget.style.backgroundColor = "var(--color-interactive-hover)";
           }}
           onMouseLeave={(e) => {
             e.currentTarget.style.backgroundColor = hasNote
-              ? isDark
-                ? "rgba(74, 171, 247, 0.15)"
-                : "rgba(34, 139, 230, 0.1)"
+              ? "var(--color-interactive-selected)"
               : "transparent";
           }}
         >

--- a/src/components/CalendarModal.tsx
+++ b/src/components/CalendarModal.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Group, Modal, Stack, Text, useComputedColorScheme } from "@mantine/core";
+import { Box, Button, Group, Modal, Stack, Text } from "@mantine/core";
 import { useState } from "react";
 import { usePageStore } from "../stores/pageStore";
 import { useViewStore } from "../stores/viewStore";
@@ -9,8 +9,6 @@ interface CalendarModalProps {
 }
 
 export function CalendarModal({ opened, onClose }: CalendarModalProps) {
-  const computedColorScheme = useComputedColorScheme("light");
-  const isDark = computedColorScheme === "dark";
   const [currentDate, setCurrentDate] = useState(new Date());
   const pagesById = usePageStore((state) => state.pagesById);
   const pageIds = usePageStore((state) => state.pageIds);
@@ -149,27 +147,21 @@ export function CalendarModal({ opened, onClose }: CalendarModalProps) {
             cursor: "pointer",
             borderRadius: "6px",
             border: isToday
-              ? `2px solid ${isDark ? "#4dabf7" : "#228be6"}`
+              ? "2px solid var(--color-accent)"
               : "2px solid transparent",
             backgroundColor: hasNote
-              ? isDark
-                ? "rgba(74, 171, 247, 0.15)"
-                : "rgba(34, 139, 230, 0.1)"
+              ? "var(--color-interactive-selected)"
               : "transparent",
             transition: "all 0.15s ease",
             fontWeight: hasNote ? 600 : 400,
-            color: isDark ? "#c1c2c5" : "#495057",
+            color: "var(--color-text-secondary)",
           }}
           onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor = isDark
-              ? "rgba(255, 255, 255, 0.08)"
-              : "rgba(0, 0, 0, 0.05)";
+            e.currentTarget.style.backgroundColor = "var(--color-interactive-hover)";
           }}
           onMouseLeave={(e) => {
             e.currentTarget.style.backgroundColor = hasNote
-              ? isDark
-                ? "rgba(74, 171, 247, 0.15)"
-                : "rgba(34, 139, 230, 0.1)"
+              ? "var(--color-interactive-selected)"
               : "transparent";
           }}
         >
@@ -253,9 +245,7 @@ export function CalendarModal({ opened, onClose }: CalendarModalProps) {
             marginTop: "8px",
             padding: "12px",
             borderRadius: "6px",
-            backgroundColor: isDark
-              ? "rgba(255, 255, 255, 0.03)"
-              : "rgba(0, 0, 0, 0.02)",
+            backgroundColor: "var(--color-bg-secondary)",
           }}
         >
           <Stack gap="xs">
@@ -265,7 +255,7 @@ export function CalendarModal({ opened, onClose }: CalendarModalProps) {
                   width: "16px",
                   height: "16px",
                   borderRadius: "4px",
-                  border: `2px solid ${isDark ? "#4dabf7" : "#228be6"}`,
+                  border: "2px solid var(--color-accent)",
                 }}
               />
               <Text size="xs" c="dimmed">
@@ -278,9 +268,7 @@ export function CalendarModal({ opened, onClose }: CalendarModalProps) {
                   width: "16px",
                   height: "16px",
                   borderRadius: "4px",
-                  backgroundColor: isDark
-                    ? "rgba(74, 171, 247, 0.15)"
-                    : "rgba(34, 139, 230, 0.1)",
+                  backgroundColor: "var(--color-interactive-selected)",
                 }}
               />
               <Text size="xs" c="dimmed">

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { Box, Kbd, Modal, Stack, Text, TextInput, useComputedColorScheme } from "@mantine/core";
+import { Box, Kbd, Modal, Stack, Text, TextInput } from "@mantine/core";
 import {
   IconFile,
   IconFolderPlus,
@@ -38,8 +38,6 @@ export function CommandPalette({
   onOpenSettings,
   onOpenHelp,
 }: CommandPaletteProps) {
-  const computedColorScheme = useComputedColorScheme("light");
-  const isDark = computedColorScheme === "dark";
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
 
@@ -324,15 +322,11 @@ export function CommandPalette({
                     cursor: "pointer",
                     backgroundColor:
                       selectedIndex === index
-                        ? isDark
-                          ? "rgba(255, 255, 255, 0.08)"
-                          : "rgba(0, 0, 0, 0.05)"
+                        ? "var(--color-interactive-hover)"
                         : "transparent",
                     border: `1px solid ${
                       selectedIndex === index
-                        ? isDark
-                          ? "#373A40"
-                          : "#dee2e6"
+                        ? "var(--color-border-secondary)"
                         : "transparent"
                     }`,
                     transition: "all 0.15s ease",
@@ -348,7 +342,7 @@ export function CommandPalette({
                   >
                     <div
                       style={{
-                        color: isDark ? "#909296" : "#868e96",
+                        color: "var(--color-text-tertiary)",
                         display: "flex",
                         alignItems: "center",
                       }}
@@ -359,7 +353,7 @@ export function CommandPalette({
                       <Text
                         size="sm"
                         style={{
-                          color: isDark ? "#c1c2c5" : "#495057",
+                          color: "var(--color-text-secondary)",
                           fontSize: "0.9rem",
                           marginBottom: command.description ? "2px" : 0,
                         }}
@@ -370,7 +364,7 @@ export function CommandPalette({
                         <Text
                           size="xs"
                           style={{
-                            color: isDark ? "#909296" : "#868e96",
+                            color: "var(--color-text-tertiary)",
                             fontSize: "0.8rem",
                           }}
                         >

--- a/src/components/GitStatusIndicator.tsx
+++ b/src/components/GitStatusIndicator.tsx
@@ -1,5 +1,5 @@
 import { useGitManagement } from "@/hooks/useGitManagement";
-import { Button, Stack, Text, useComputedColorScheme } from "@mantine/core";
+import { Button, Stack, Text } from "@mantine/core";
 
 interface GitStatusIndicatorProps {
   workspacePath: string;
@@ -16,9 +16,6 @@ interface GitStatusIndicatorProps {
  * - Status tooltips
  */
 export function GitStatusIndicator({ workspacePath }: GitStatusIndicatorProps) {
-  const computedColorScheme = useComputedColorScheme("light");
-  const isDark = computedColorScheme === "dark";
-
   const {
     hasChanges,
     isRepo,
@@ -55,12 +52,8 @@ export function GitStatusIndicator({ workspacePath }: GitStatusIndicatorProps) {
           height: "8px",
           borderRadius: "50%",
           backgroundColor: hasChanges
-            ? isDark
-              ? "#ffd43b"
-              : "#fab005"
-            : isDark
-              ? "#5c5f66"
-              : "#adb5bd",
+            ? "var(--color-warning)"
+            : "var(--color-text-tertiary)",
           cursor: "pointer",
           opacity: hasChanges ? 1 : 0.4,
           transition: "opacity 0.2s ease, background-color 0.2s ease",
@@ -78,8 +71,8 @@ export function GitStatusIndicator({ workspacePath }: GitStatusIndicatorProps) {
             position: "absolute",
             bottom: "20px",
             right: "0",
-            backgroundColor: isDark ? "#25262b" : "#ffffff",
-            border: `1px solid ${isDark ? "#373A40" : "#DEE2E6"}`,
+            backgroundColor: "var(--color-bg-elevated)",
+            border: "1px solid var(--color-border-secondary)",
             borderRadius: "6px",
             padding: "8px",
             minWidth: "140px",

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -1,5 +1,4 @@
 import { Box, Modal, ScrollArea } from "@mantine/core";
-import { useComputedColorScheme } from "@mantine/core";
 import MarkdownIt from "markdown-it";
 import { useMemo } from "react";
 
@@ -201,9 +200,6 @@ Blocks are stored as nested bullet lists in markdown:
 Thank you for using MD Outliner! Happy note-taking! 📝`;
 
 export function HelpModal({ opened, onClose }: HelpModalProps) {
-  const computedColorScheme = useComputedColorScheme("light");
-  const isDark = computedColorScheme === "dark";
-
   const md = useMemo(() => {
     return new MarkdownIt({
       html: false,
@@ -242,7 +238,7 @@ export function HelpModal({ opened, onClose }: HelpModalProps) {
             // biome-ignore lint/security/noDangerouslySetInnerHtml: The markdown content is static (HELP_CONTENT) and the HTML output is produced by markdown-it with HTML parsing disabled (html: false). This is safe for rendering the help documentation.
             dangerouslySetInnerHTML={{ __html: htmlContent }}
             style={{
-              color: isDark ? "#c1c2c5" : "#495057",
+              color: "var(--color-text-secondary)",
               lineHeight: 1.6,
               fontSize: "0.95rem",
             }}
@@ -258,7 +254,7 @@ export function HelpModal({ opened, onClose }: HelpModalProps) {
             font-weight: 700;
             margin-top: 0;
             margin-bottom: 1rem;
-            color: ${isDark ? "#f8f9fa" : "#212529"};
+            color: var(--color-text-primary);
           }
 
           .help-content h2 {
@@ -266,8 +262,8 @@ export function HelpModal({ opened, onClose }: HelpModalProps) {
             font-weight: 600;
             margin-top: 2rem;
             margin-bottom: 1rem;
-            color: ${isDark ? "#e9ecef" : "#343a40"};
-            border-bottom: 1px solid ${isDark ? "#373a40" : "#dee2e6"};
+            color: var(--color-text-primary);
+            border-bottom: 1px solid var(--color-border-secondary);
             padding-bottom: 0.5rem;
           }
 
@@ -276,7 +272,7 @@ export function HelpModal({ opened, onClose }: HelpModalProps) {
             font-weight: 600;
             margin-top: 1.5rem;
             margin-bottom: 0.75rem;
-            color: ${isDark ? "#dee2e6" : "#495057"};
+            color: var(--color-text-secondary);
           }
 
           .help-content p {
@@ -293,34 +289,32 @@ export function HelpModal({ opened, onClose }: HelpModalProps) {
           }
 
           .help-content code {
-            background-color: ${
-              isDark ? "rgba(255, 255, 255, 0.1)" : "rgba(0, 0, 0, 0.05)"
-            };
+            background-color: var(--color-bg-secondary);
             padding: 2px 6px;
             border-radius: 3px;
             font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
             font-size: 0.9em;
-            color: ${isDark ? "#ff6b6b" : "#c92a2a"};
+            color: var(--color-error);
           }
 
           .help-content pre {
-            background-color: ${isDark ? "#1a1b1e" : "#f8f9fa"};
+            background-color: var(--color-bg-secondary);
             padding: 1rem;
             border-radius: 6px;
             overflow-x: auto;
             margin-bottom: 1rem;
-            border: 1px solid ${isDark ? "#373a40" : "#dee2e6"};
+            border: 1px solid var(--color-border-secondary);
           }
 
           .help-content pre code {
             background-color: transparent;
             padding: 0;
-            color: ${isDark ? "#c1c2c5" : "#495057"};
+            color: var(--color-text-secondary);
           }
 
           .help-content strong {
             font-weight: 600;
-            color: ${isDark ? "#f8f9fa" : "#212529"};
+            color: var(--color-text-primary);
           }
 
           .help-content em {
@@ -329,12 +323,12 @@ export function HelpModal({ opened, onClose }: HelpModalProps) {
 
           .help-content hr {
             border: none;
-            border-top: 1px solid ${isDark ? "#373a40" : "#dee2e6"};
+            border-top: 1px solid var(--color-border-secondary);
             margin: 2rem 0;
           }
 
           .help-content a {
-            color: ${isDark ? "#4dabf7" : "#228be6"};
+            color: var(--color-text-link);
             text-decoration: none;
           }
 

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -1,4 +1,4 @@
-import { Box, Loader, Modal, Stack, Text, TextInput, useComputedColorScheme } from "@mantine/core";
+import { Box, Loader, Modal, Stack, Text, TextInput } from "@mantine/core";
 import { IconFile, IconFolder, IconSearch } from "@tabler/icons-react";
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -27,8 +27,6 @@ interface FlatPageItem {
 }
 
 export function SearchModal({ opened, onClose }: SearchModalProps) {
-  const computedColorScheme = useComputedColorScheme("light");
-  const isDark = computedColorScheme === "dark";
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -195,8 +193,8 @@ export function SearchModal({ opened, onClose }: SearchModalProps) {
               <span
                 key={`${pageId}-highlight-${partCounter}`}
                 style={{
-                  backgroundColor: isDark ? "#ffd43b" : "#fff3bf",
-                  color: isDark ? "#000" : "#000",
+                  backgroundColor: "var(--color-interactive-selected)",
+                  color: "inherit",
                   fontWeight: 600,
                 }}
               >
@@ -242,15 +240,11 @@ export function SearchModal({ opened, onClose }: SearchModalProps) {
                   borderRadius: "6px",
                   cursor: "pointer",
                   backgroundColor: isSelected
-                    ? isDark
-                      ? "rgba(255, 255, 255, 0.08)"
-                      : "rgba(0, 0, 0, 0.05)"
+                    ? "var(--color-interactive-selected)"
                     : "transparent",
                   border: `1px solid ${
                     isSelected
-                      ? isDark
-                        ? "#373A40"
-                        : "#dee2e6"
+                      ? "var(--color-border-secondary)"
                       : "transparent"
                   }`,
                   transition: "all 0.15s ease",
@@ -282,7 +276,7 @@ export function SearchModal({ opened, onClose }: SearchModalProps) {
                         fontSize: "0.7rem",
                         userSelect: "none",
                         width: "12px",
-                        color: isDark ? "#909296" : "#868e96",
+                        color: "var(--color-text-tertiary)",
                         border: "none",
                         background: "none",
                         padding: "0",
@@ -297,18 +291,18 @@ export function SearchModal({ opened, onClose }: SearchModalProps) {
                   {page.isDirectory ? (
                     <IconFolder
                       size={14}
-                      style={{ color: isDark ? "#909296" : "#868e96" }}
+                      style={{ color: "var(--color-text-tertiary)" }}
                     />
                   ) : (
                     <IconFile
                       size={14}
-                      style={{ color: isDark ? "#909296" : "#868e96" }}
+                      style={{ color: "var(--color-text-tertiary)" }}
                     />
                   )}
                   <Text
                     size="sm"
                     style={{
-                      color: isDark ? "#c1c2c5" : "#495057",
+                      color: "var(--color-text-secondary)",
                       fontSize: "0.9rem",
                     }}
                   >
@@ -350,15 +344,11 @@ export function SearchModal({ opened, onClose }: SearchModalProps) {
                 cursor: "pointer",
                 backgroundColor:
                   selectedIndex === index
-                    ? isDark
-                      ? "rgba(255, 255, 255, 0.08)"
-                      : "rgba(0, 0, 0, 0.05)"
+                    ? "var(--color-interactive-selected)"
                     : "transparent",
                 border: `1px solid ${
                   selectedIndex === index
-                    ? isDark
-                      ? "#373A40"
-                      : "#dee2e6"
+                    ? "var(--color-border-secondary)"
                     : "transparent"
                 }`,
                 transition: "all 0.15s ease",
@@ -375,19 +365,19 @@ export function SearchModal({ opened, onClose }: SearchModalProps) {
                 {result.result_type === "page" ? (
                   <IconFile
                     size={14}
-                    style={{ color: isDark ? "#909296" : "#868e96" }}
+                    style={{ color: "var(--color-text-tertiary)" }}
                   />
                 ) : (
                   <IconFile
                     size={14}
-                    style={{ color: isDark ? "#909296" : "#868e96" }}
+                    style={{ color: "var(--color-text-tertiary)" }}
                   />
                 )}
                 <div style={{ flex: 1, minWidth: 0 }}>
                   <Text
                     size="sm"
                     style={{
-                      color: isDark ? "#c1c2c5" : "#495057",
+                      color: "var(--color-text-secondary)",
                       fontSize: "0.9rem",
                       marginBottom: "2px",
                     }}
@@ -397,7 +387,7 @@ export function SearchModal({ opened, onClose }: SearchModalProps) {
                   <Text
                     size="xs"
                     style={{
-                      color: isDark ? "#909296" : "#868e96",
+                      color: "var(--color-text-tertiary)",
                       lineHeight: 1.4,
                       fontSize: "0.8rem",
                     }}

--- a/src/components/fileTree/PageTreeItem.tsx
+++ b/src/components/fileTree/PageTreeItem.tsx
@@ -313,7 +313,7 @@ export function PageTreeItem({
                   }}
                   style={{
                     flex: 1,
-                    color: "#8b5cf6",
+                    color: "var(--color-accent)",
                     userSelect: "none",
                     fontSize: "var(--font-size-sm)",
                     lineHeight: "24px",

--- a/src/components/settings/AboutSettings.tsx
+++ b/src/components/settings/AboutSettings.tsx
@@ -5,7 +5,6 @@ import {
   Progress,
   Stack,
   Text,
-  useComputedColorScheme,
 } from "@mantine/core";
 import { IconDownload } from "@tabler/icons-react";
 import { useTranslation } from "react-i18next";
@@ -14,7 +13,6 @@ import type { AboutSettingsProps } from "./types";
 
 export function AboutSettings({ appVersion }: AboutSettingsProps) {
   const { t } = useTranslation();
-  const isDark = useComputedColorScheme("light") === "dark";
 
   return (
     <Stack gap="xl">
@@ -41,8 +39,8 @@ export function AboutSettings({ appVersion }: AboutSettingsProps) {
             style={{
               padding: 16,
               borderRadius: 8,
-              backgroundColor: isDark ? "#2C2E33" : "#F1F3F5",
-              border: `1px solid ${isDark ? "#373A40" : "#E9ECEF"}`,
+              backgroundColor: "var(--color-bg-tertiary)",
+              border: "1px solid var(--color-border-primary)",
             }}
           >
             <Group justify="space-between" mb={8} align="flex-start">
@@ -121,7 +119,7 @@ export function AboutSettings({ appVersion }: AboutSettingsProps) {
                           maxHeight: 150,
                           overflowY: "auto",
                           padding: 8,
-                          backgroundColor: isDark ? "#25262B" : "#fff",
+                          backgroundColor: "var(--color-bg-elevated)",
                           borderRadius: 4,
                           fontSize: 12,
                         }}

--- a/src/components/settings/AdvancedSettings.tsx
+++ b/src/components/settings/AdvancedSettings.tsx
@@ -3,7 +3,6 @@ import {
   Stack,
   Switch,
   Text,
-  useComputedColorScheme,
 } from "@mantine/core";
 import { IconTrash } from "@tabler/icons-react";
 import { useTranslation } from "react-i18next";
@@ -17,7 +16,6 @@ export function AdvancedSettings({
   clearCache,
 }: AdvancedSettingsProps) {
   const { t } = useTranslation();
-  const isDark = useComputedColorScheme("light") === "dark";
 
   return (
     <Stack gap="xl">
@@ -56,8 +54,8 @@ export function AdvancedSettings({
               style={{
                 padding: 16,
                 borderRadius: 6,
-                backgroundColor: isDark ? "#2C2E33" : "#F1F3F5",
-                borderLeft: `3px solid ${isDark ? "#4C6EF5" : "#5C7CFA"}`,
+                backgroundColor: "var(--color-bg-tertiary)",
+                borderLeft: "3px solid var(--color-accent)",
               }}
             >
               <Text size="sm" fw={500} mb={12}>
@@ -81,8 +79,8 @@ export function AdvancedSettings({
               style={{
                 padding: 16,
                 borderRadius: 6,
-                backgroundColor: isDark ? "#2C2E33" : "#F1F3F5",
-                borderLeft: `3px solid ${isDark ? "#FA5252" : "#FF6B6B"}`,
+                backgroundColor: "var(--color-bg-tertiary)",
+                borderLeft: "3px solid var(--color-error)",
               }}
             >
               <Text size="sm" fw={500} mb={12} c="red">

--- a/src/components/settings/AppearanceSettings.tsx
+++ b/src/components/settings/AppearanceSettings.tsx
@@ -4,7 +4,6 @@ import {
   Slider,
   Stack,
   Text,
-  useComputedColorScheme,
 } from "@mantine/core";
 import { useTranslation } from "react-i18next";
 import type { FontFamily } from "../../stores/themeStore";
@@ -22,7 +21,6 @@ export function AppearanceSettings({
   fontOptions,
 }: AppearanceSettingsProps) {
   const { t } = useTranslation();
-  const isDark = useComputedColorScheme("light") === "dark";
 
   return (
     <Stack gap="xl">
@@ -57,7 +55,7 @@ export function AppearanceSettings({
                   marginTop: 12,
                   padding: 16,
                   borderRadius: 6,
-                  backgroundColor: isDark ? "#2C2E33" : "#F1F3F5",
+                  backgroundColor: "var(--color-bg-tertiary)",
                   fontFamily: getFontStack(),
                 }}
               >

--- a/src/components/settings/DatetimeSettings.tsx
+++ b/src/components/settings/DatetimeSettings.tsx
@@ -1,4 +1,4 @@
-import { Select, Stack, Text, useComputedColorScheme } from "@mantine/core";
+import { Select, Stack, Text } from "@mantine/core";
 import { useTranslation } from "react-i18next";
 import type {
   DateOrder,
@@ -91,7 +91,6 @@ export function DatetimeSettings({
   setTimezone,
 }: DatetimeSettingsProps) {
   const { t } = useTranslation();
-  const isDark = useComputedColorScheme("light") === "dark";
 
   return (
     <Stack gap="xl">
@@ -182,7 +181,7 @@ export function DatetimeSettings({
               style={{
                 padding: 16,
                 borderRadius: 6,
-                backgroundColor: isDark ? "#2C2E33" : "#F1F3F5",
+                backgroundColor: "var(--color-bg-tertiary)",
               }}
             >
               <Text size="sm" fw={500} mb={4}>

--- a/src/components/settings/GitSettings.tsx
+++ b/src/components/settings/GitSettings.tsx
@@ -6,7 +6,6 @@ import {
   Switch,
   Text,
   Tooltip,
-  useComputedColorScheme,
 } from "@mantine/core";
 import { IconBrandGit, IconPlus, IconX } from "@tabler/icons-react";
 import { useTranslation } from "react-i18next";
@@ -29,7 +28,6 @@ export function GitSettings({
   workspacePath,
 }: GitSettingsProps) {
   const { t } = useTranslation();
-  const isDark = useComputedColorScheme("light") === "dark";
 
   const handleGitCommit = async () => {
     if (!workspacePath || !hasGitChanges) return;
@@ -81,7 +79,7 @@ export function GitSettings({
                   style={{
                     padding: 16,
                     borderRadius: 6,
-                    backgroundColor: isDark ? "#2C2E33" : "#F1F3F5",
+                    backgroundColor: "var(--color-bg-tertiary)",
                   }}
                 >
                   <Text size="sm" fw={500} mb={8}>
@@ -105,7 +103,7 @@ export function GitSettings({
                     c="dimmed"
                     style={{
                       fontFamily: "monospace",
-                      backgroundColor: isDark ? "#2C2E33" : "#F1F3F5",
+                      backgroundColor: "var(--color-bg-tertiary)",
                       padding: "8px 12px",
                       borderRadius: "4px",
                       wordBreak: "break-all",
@@ -156,8 +154,8 @@ export function GitSettings({
                   style={{
                     padding: 16,
                     borderRadius: 6,
-                    backgroundColor: isDark ? "#2C2E33" : "#F1F3F5",
-                    borderLeft: `3px solid ${isDark ? "#4C6EF5" : "#5C7CFA"}`,
+                    backgroundColor: "var(--color-bg-tertiary)",
+                    borderLeft: "3px solid var(--color-accent)",
                   }}
                 >
                   <Text size="sm" fw={500} mb={8}>
@@ -205,8 +203,8 @@ export function GitSettings({
                   style={{
                     padding: 16,
                     borderRadius: 6,
-                    backgroundColor: isDark ? "#2C2E33" : "#F1F3F5",
-                    borderLeft: `3px solid ${isDark ? "#4C6EF5" : "#5C7CFA"}`,
+                    backgroundColor: "var(--color-bg-tertiary)",
+                    borderLeft: "3px solid var(--color-accent)",
                   }}
                 >
                   <Text size="sm" fw={500} mb={8}>

--- a/src/components/settings/ShortcutsSettings.tsx
+++ b/src/components/settings/ShortcutsSettings.tsx
@@ -3,14 +3,12 @@ import {
   Group,
   Stack,
   Text,
-  useComputedColorScheme,
 } from "@mantine/core";
 import { useTranslation } from "react-i18next";
 import type { ShortcutsSettingsProps } from "./types";
 
 export function ShortcutsSettings({ matchesSearch }: ShortcutsSettingsProps) {
   const { t } = useTranslation();
-  const isDark = useComputedColorScheme("light") === "dark";
 
   return (
     <Stack gap="xl">
@@ -28,7 +26,7 @@ export function ShortcutsSettings({ matchesSearch }: ShortcutsSettingsProps) {
               style={{
                 padding: 16,
                 borderRadius: 6,
-                backgroundColor: isDark ? "#2C2E33" : "#F1F3F5",
+                backgroundColor: "var(--color-bg-tertiary)",
               }}
             >
               <Group justify="space-between" mb={8}>

--- a/src/components/titleBar/Clock.tsx
+++ b/src/components/titleBar/Clock.tsx
@@ -1,11 +1,9 @@
-import { Box, Popover, Text, useComputedColorScheme } from "@mantine/core";
+import { Box, Popover, Text } from "@mantine/core";
 import { useEffect, useState } from "react";
 import { useClockFormatStore } from "../../stores/clockFormatStore";
 import { CalendarDropdown } from "../CalendarDropdown";
 
 export function Clock() {
-  const computedColorScheme = useComputedColorScheme("light");
-  const isDark = computedColorScheme === "dark";
   const [time, setTime] = useState<string>("");
   const [date, setDate] = useState<string>("");
   const [opened, setOpened] = useState(false);
@@ -52,21 +50,15 @@ export function Clock() {
             borderRadius: "4px",
             transition: "background-color 0.2s ease",
             backgroundColor: opened
-              ? isDark
-                ? "rgba(255, 255, 255, 0.1)"
-                : "rgba(0, 0, 0, 0.05)"
+              ? "var(--color-interactive-active)"
               : "transparent",
           }}
           onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor = isDark
-              ? "rgba(255, 255, 255, 0.08)"
-              : "rgba(0, 0, 0, 0.03)";
+            e.currentTarget.style.backgroundColor = "var(--color-interactive-hover)";
           }}
           onMouseLeave={(e) => {
             e.currentTarget.style.backgroundColor = opened
-              ? isDark
-                ? "rgba(255, 255, 255, 0.1)"
-                : "rgba(0, 0, 0, 0.05)"
+              ? "var(--color-interactive-active)"
               : "transparent";
           }}
         >
@@ -106,11 +98,9 @@ export function Clock() {
         style={{
           padding: "16px",
           borderRadius: "12px",
-          backgroundColor: isDark ? "#1a1b1e" : "#ffffff",
-          border: `1px solid ${isDark ? "rgba(255, 255, 255, 0.1)" : "rgba(0, 0, 0, 0.1)"}`,
-          boxShadow: isDark
-            ? "0 8px 24px rgba(0, 0, 0, 0.4)"
-            : "0 8px 24px rgba(0, 0, 0, 0.12)",
+          backgroundColor: "var(--color-bg-elevated)",
+          border: "1px solid var(--color-border-primary)",
+          boxShadow: "var(--shadow-lg)", // Assuming shadow variable or use generic
         }}
       >
         <CalendarDropdown onClose={handleClose} />

--- a/src/components/titleBar/WindowControls.tsx
+++ b/src/components/titleBar/WindowControls.tsx
@@ -82,7 +82,7 @@ export function WindowControls({ show = true }: WindowControlsProps) {
             borderRadius: "0",
             "&:hover": {
               backgroundColor: "var(--color-error)",
-              color: "#ffffff",
+              color: "white",
             },
           },
         }}

--- a/src/editor/createEditor.ts
+++ b/src/editor/createEditor.ts
@@ -1207,41 +1207,39 @@ function createEditorTheme(theme: "light" | "dark" = "light"): Extension {
       "&": {
         height: "100%",
         fontSize: "14px",
-        backgroundColor: isDark ? "#1e1e1e" : "#ffffff",
-        color: isDark ? "#d4d4d4" : "#000000",
+        backgroundColor: "var(--color-bg-primary)",
+        color: "var(--color-text-primary)",
       },
       ".cm-content": {
         padding: "20px 0",
         fontFamily:
           "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
-        caretColor: isDark ? "#ffffff" : "#000000",
+        caretColor: "var(--color-text-primary)",
       },
       ".cm-line": {
         padding: "0 20px",
         lineHeight: "1.6",
       },
       ".cm-gutters": {
-        backgroundColor: isDark ? "#252526" : "#f5f5f5",
-        color: isDark ? "#858585" : "#858585",
+        backgroundColor: "var(--color-bg-elevated)",
+        color: "var(--color-text-tertiary)",
         border: "none",
         paddingLeft: "8px",
       },
       ".cm-activeLineGutter": {
-        backgroundColor: isDark ? "#2c2c2d" : "#e8e8e8",
+        backgroundColor: "var(--color-interactive-hover)",
       },
       ".cm-activeLine": {
-        backgroundColor: isDark
-          ? "rgba(255, 255, 255, 0.05)"
-          : "rgba(0, 0, 0, 0.03)",
+        backgroundColor: "var(--color-interactive-hover)",
       },
       ".cm-selectionBackground, ::selection": {
-        backgroundColor: isDark ? "#264f78" : "#b3d4fc",
+        backgroundColor: "var(--color-interactive-selected)",
       },
       ".cm-focused .cm-selectionBackground, .cm-focused ::selection": {
-        backgroundColor: isDark ? "#264f78" : "#b3d4fc",
+        backgroundColor: "var(--color-interactive-selected)",
       },
       ".cm-cursor": {
-        borderLeftColor: isDark ? "#ffffff" : "#000000",
+        borderLeftColor: "var(--color-text-primary)",
       },
       "&.cm-focused": {
         outline: "none",

--- a/src/editor/extensions/handlers/CalloutHandler.ts
+++ b/src/editor/extensions/handlers/CalloutHandler.ts
@@ -40,26 +40,46 @@ export class CalloutHandler extends BaseHandler {
     string,
     { color: string; bgColor: string; icon: string }
   > = {
-    note: { color: "#3b82f6", bgColor: "rgba(59, 130, 246, 0.1)", icon: "ℹ️" },
-    info: { color: "#3b82f6", bgColor: "rgba(59, 130, 246, 0.1)", icon: "ℹ️" },
-    tip: { color: "#10b981", bgColor: "rgba(16, 185, 129, 0.1)", icon: "💡" },
+    note: {
+      color: "var(--color-text-link)",
+      bgColor: "color-mix(in srgb, var(--color-text-link), transparent 90%)",
+      icon: "ℹ️",
+    },
+    info: {
+      color: "var(--color-text-link)",
+      bgColor: "color-mix(in srgb, var(--color-text-link), transparent 90%)",
+      icon: "ℹ️",
+    },
+    tip: {
+      color: "var(--color-success)",
+      bgColor: "color-mix(in srgb, var(--color-success), transparent 90%)",
+      icon: "💡",
+    },
     success: {
-      color: "#10b981",
-      bgColor: "rgba(16, 185, 129, 0.1)",
+      color: "var(--color-success)",
+      bgColor: "color-mix(in srgb, var(--color-success), transparent 90%)",
       icon: "✅",
     },
     question: {
-      color: "#8b5cf6",
-      bgColor: "rgba(139, 92, 246, 0.1)",
+      color: "var(--color-accent)",
+      bgColor: "color-mix(in srgb, var(--color-accent), transparent 90%)",
       icon: "❓",
     },
     warning: {
-      color: "#f59e0b",
-      bgColor: "rgba(245, 158, 11, 0.1)",
+      color: "var(--color-warning)",
+      bgColor: "color-mix(in srgb, var(--color-warning), transparent 90%)",
       icon: "⚠️",
     },
-    error: { color: "#ef4444", bgColor: "rgba(239, 68, 68, 0.1)", icon: "❌" },
-    danger: { color: "#ef4444", bgColor: "rgba(239, 68, 68, 0.1)", icon: "🔥" },
+    error: {
+      color: "var(--color-error)",
+      bgColor: "color-mix(in srgb, var(--color-error), transparent 90%)",
+      icon: "❌",
+    },
+    danger: {
+      color: "var(--color-error)",
+      bgColor: "color-mix(in srgb, var(--color-error), transparent 90%)",
+      icon: "🔥",
+    },
     abstract: {
       color: "#06b6d4",
       bgColor: "rgba(6, 182, 212, 0.1)",
@@ -70,18 +90,26 @@ export class CalloutHandler extends BaseHandler {
       bgColor: "rgba(6, 182, 212, 0.1)",
       icon: "📋",
     },
-    todo: { color: "#8b5cf6", bgColor: "rgba(139, 92, 246, 0.1)", icon: "✏️" },
+    todo: {
+      color: "var(--color-accent)",
+      bgColor: "color-mix(in srgb, var(--color-accent), transparent 90%)",
+      icon: "✏️",
+    },
     example: {
-      color: "#a855f7",
-      bgColor: "rgba(168, 85, 247, 0.1)",
+      color: "var(--color-accent)",
+      bgColor: "color-mix(in srgb, var(--color-accent), transparent 90%)",
       icon: "📖",
     },
     quote: {
-      color: "#64748b",
-      bgColor: "rgba(100, 116, 139, 0.1)",
+      color: "var(--color-text-secondary)",
+      bgColor: "color-mix(in srgb, var(--color-text-secondary), transparent 90%)",
       icon: "💬",
     },
-    bug: { color: "#ef4444", bgColor: "rgba(239, 68, 68, 0.1)", icon: "🐛" },
+    bug: {
+      color: "var(--color-error)",
+      bgColor: "color-mix(in srgb, var(--color-error), transparent 90%)",
+      icon: "🐛",
+    },
   };
 
   /**

--- a/src/editor/extensions/handlers/CommentHandler.ts
+++ b/src/editor/extensions/handlers/CommentHandler.ts
@@ -53,10 +53,10 @@ export class CommentHandler extends BaseHandler {
             class: "cm-comment",
             attributes: {
               style: `
-                color: #888;
+                color: var(--color-text-tertiary);
                 opacity: 0.6;
                 font-style: italic;
-                background: rgba(128, 128, 128, 0.1);
+                background: var(--color-bg-secondary);
                 padding: 0.1em 0.3em;
                 border-radius: 3px;
               `,

--- a/src/editor/extensions/handlers/TagHandler.ts
+++ b/src/editor/extensions/handlers/TagHandler.ts
@@ -61,8 +61,8 @@ export class TagHandler extends BaseHandler {
           createStyledText(start, end, {
             className: "cm-tag",
             style: `
-              color: #10b981;
-              background: rgba(16, 185, 129, 0.1);
+              color: var(--color-success);
+              background: color-mix(in srgb, var(--color-success), transparent 90%);
               padding: 0.1em 0.3em;
               border-radius: 3px;
               cursor: pointer;

--- a/src/editor/extensions/handlers/WikiLinkHandler.ts
+++ b/src/editor/extensions/handlers/WikiLinkHandler.ts
@@ -256,7 +256,7 @@ export class WikiLinkHandler extends BaseHandler {
             createStyledText(aliasStart, aliasEnd, {
               className: "cm-wiki-link",
               style: `
-                color: #8b5cf6;
+                color: var(--color-accent);
                 cursor: pointer;
                 font-weight: 500;
                 text-decoration: none !important;
@@ -290,7 +290,7 @@ export class WikiLinkHandler extends BaseHandler {
             createStyledText(linkStart, linkEnd, {
               className: "cm-wiki-link",
               style: `
-                color: #8b5cf6;
+                color: var(--color-accent);
                 cursor: pointer;
                 font-weight: 500;
                 text-decoration: none !important;

--- a/src/editor/extensions/hybridRendering.ts
+++ b/src/editor/extensions/hybridRendering.ts
@@ -310,7 +310,7 @@ function buildDecorations(view: EditorView): DecorationSet {
             decoration: Decoration.mark({
               class: "cm-table-separator",
               attributes: {
-                style: "opacity: 0.4; color: #888;",
+                style: "opacity: 0.4; color: var(--color-text-tertiary);",
               },
             }),
           });
@@ -324,8 +324,8 @@ function buildDecorations(view: EditorView): DecorationSet {
         .filter((cell) => cell.length > 0);
 
       const rowStyle = isHeader
-        ? `display: grid; grid-template-columns: repeat(${cells.length}, 1fr); gap: 0; padding: 0.75em 0; font-weight: 600; background: linear-gradient(to bottom, rgba(128, 128, 128, 0.08), rgba(128, 128, 128, 0.12)); border: 1px solid rgba(128, 128, 128, 0.25); border-bottom: 2px solid rgba(128, 128, 128, 0.4); margin-top: 0.5em;`
-        : `display: grid; grid-template-columns: repeat(${cells.length}, 1fr); gap: 0; padding: 0.6em 0; border-left: 1px solid rgba(128, 128, 128, 0.25); border-right: 1px solid rgba(128, 128, 128, 0.25); border-bottom: 1px solid rgba(128, 128, 128, 0.25);`;
+        ? `display: grid; grid-template-columns: repeat(${cells.length}, 1fr); gap: 0; padding: 0.75em 0; font-weight: 600; background: var(--color-interactive-hover); border: 1px solid var(--color-border-primary); border-bottom: 2px solid var(--color-border-secondary); margin-top: 0.5em;`
+        : `display: grid; grid-template-columns: repeat(${cells.length}, 1fr); gap: 0; padding: 0.6em 0; border-left: 1px solid var(--color-border-primary); border-right: 1px solid var(--color-border-primary); border-bottom: 1px solid var(--color-border-primary);`;
 
       decorations.push({
         from: line.from,
@@ -354,7 +354,7 @@ function buildDecorations(view: EditorView): DecorationSet {
             attributes: {
               style: `padding: 0 1em; ${
                 idx < cells.length - 1
-                  ? "border-right: 1px solid rgba(128, 128, 128, 0.2);"
+                  ? "border-right: 1px solid var(--color-border-primary);"
                   : ""
               }`,
             },
@@ -385,7 +385,7 @@ function buildDecorations(view: EditorView): DecorationSet {
             to: line.from + i + 1,
             decoration: Decoration.mark({
               class: "cm-table-pipe",
-              attributes: { style: "opacity: 0.3; color: #888;" },
+              attributes: { style: "opacity: 0.3; color: var(--color-text-tertiary);" },
             }),
           });
         }
@@ -466,7 +466,7 @@ function buildDecorations(view: EditorView): DecorationSet {
               class: "cm-footnote-def",
               attributes: {
                 style:
-                  "color: #888; font-size: 0.9em; font-style: italic; opacity: 0.7;",
+                  "color: var(--color-text-tertiary); font-size: 0.9em; font-style: italic; opacity: 0.7;",
               },
             }),
           });
@@ -484,11 +484,10 @@ function buildDecorations(view: EditorView): DecorationSet {
           to: refEnd,
           decoration: Decoration.mark({
             class: "cm-footnote-ref",
-            attributes: {
-              style:
-                "color: #4dabf7; font-size: 0.85em; vertical-align: super; cursor: pointer;",
-            },
-          }),
+                          attributes: {
+                            style:
+                              "color: var(--color-text-link); font-size: 0.85em; vertical-align: super; cursor: pointer;",
+                          },          }),
         });
         match = footnoteRefRegex.exec(lineText);
       }
@@ -609,7 +608,7 @@ export const hybridRenderingPlugin = ViewPlugin.fromClass(
 export const hybridRenderingTheme = EditorView.theme({
   // Task checkbox styling
   ".cm-task-checkbox": {
-    accentColor: "#0969da",
+    accentColor: "var(--color-accent)",
   },
 
   // Heading general styling
@@ -704,7 +703,7 @@ export const hybridRenderingTheme = EditorView.theme({
   // Inline code
   ".cm-inline-code": {
     fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', monospace",
-    backgroundColor: "rgba(127, 127, 127, 0.1)",
+    backgroundColor: "var(--color-bg-secondary)",
     padding: "0.2em 0.4em",
     borderRadius: "3px",
     fontSize: "0.9em",
@@ -712,17 +711,17 @@ export const hybridRenderingTheme = EditorView.theme({
 
   // Link text
   ".cm-link-text": {
-    color: "#0969da",
+    color: "var(--color-text-link)",
     textDecoration: "underline",
     cursor: "pointer",
   },
 
   // Blockquote
   ".cm-blockquote": {
-    borderLeft: "3px solid rgba(127, 127, 127, 0.3)",
+    borderLeft: "3px solid var(--color-border-primary)",
     paddingLeft: "12px",
     marginLeft: "4px",
-    color: "rgba(127, 127, 127, 0.8)",
+    color: "var(--color-text-secondary)",
     fontStyle: "italic",
   },
 
@@ -739,7 +738,7 @@ export const hybridRenderingTheme = EditorView.theme({
 
   ".cm-table-separator": {
     opacity: "0.3",
-    color: "#858585",
+    color: "var(--color-text-tertiary)",
   },
 
   ".cm-table-separator-hidden": {
@@ -753,13 +752,13 @@ export const hybridRenderingTheme = EditorView.theme({
 
   ".cm-table-delimiter": {
     opacity: "0.4",
-    color: "#858585",
+    color: "var(--color-text-tertiary)",
     padding: "0 4px",
   },
 
   ".cm-table-pipe": {
     opacity: "0.3",
-    color: "#858585",
+    color: "var(--color-text-tertiary)",
   },
 
   ".cm-table-pipe-hidden": {
@@ -771,7 +770,7 @@ export const hybridRenderingTheme = EditorView.theme({
   ".cm-table-header": {
     display: "table-header-group",
     fontWeight: "600",
-    background: "rgba(127, 127, 127, 0.1)",
+    background: "var(--color-interactive-hover)",
   },
 
   ".cm-table-body-row": {
@@ -790,14 +789,14 @@ export const hybridRenderingTheme = EditorView.theme({
 
   // Autolink (for future autolink handler)
   ".cm-autolink": {
-    color: "#0969da",
+    color: "var(--color-text-link)",
     textDecoration: "underline",
     cursor: "pointer",
   },
 
   // Footnote reference (for future footnote handler)
   ".cm-footnote-ref": {
-    color: "#0969da",
+    color: "var(--color-text-link)",
     fontSize: "0.85em",
     verticalAlign: "super",
     cursor: "pointer",
@@ -805,7 +804,7 @@ export const hybridRenderingTheme = EditorView.theme({
 
   // Footnote definition (for future footnote handler)
   ".cm-footnote-def": {
-    color: "rgba(127, 127, 127, 0.8)",
+    color: "var(--color-text-secondary)",
     fontSize: "0.9em",
     fontStyle: "italic",
     opacity: "0.8",
@@ -813,7 +812,7 @@ export const hybridRenderingTheme = EditorView.theme({
 
   // Obsidian features
   ".cm-wiki-link": {
-    color: "#8b5cf6",
+    color: "var(--color-accent)",
     textDecoration: "none !important",
   },
   ".cm-content .cm-wiki-link": {
@@ -840,23 +839,23 @@ export const hybridRenderingTheme = EditorView.theme({
   // Block references / embeds
   // ((uuid)) and !((uuid)) are rendered as token-like highlights; UUID is hidden by handler.
   ".cm-block-ref": {
-    color: "#8b5cf6",
+    color: "var(--color-accent)",
     textDecoration: "none",
     cursor: "pointer",
     fontWeight: 500,
     padding: "0 2px",
     borderRadius: "4px",
-    background: "rgba(139, 92, 246, 0.12)",
+    background: "color-mix(in srgb, var(--color-accent), transparent 88%)",
   },
   ".cm-block-embed": {
-    color: "#8b5cf6",
+    color: "var(--color-accent)",
     textDecoration: "none",
     cursor: "pointer",
     fontWeight: 600,
     padding: "0 2px",
     borderRadius: "4px",
-    background: "rgba(139, 92, 246, 0.18)",
-    boxShadow: "inset 0 0 0 1px rgba(139, 92, 246, 0.35)",
+    background: "color-mix(in srgb, var(--color-accent), transparent 82%)",
+    boxShadow: "inset 0 0 0 1px color-mix(in srgb, var(--color-accent), transparent 65%)",
   },
 
   // Embed subtree widget container (read-only)
@@ -870,8 +869,8 @@ export const hybridRenderingTheme = EditorView.theme({
   },
 
   ".cm-tag": {
-    color: "#10b981",
-    background: "rgba(16, 185, 129, 0.1)",
+    color: "var(--color-success)",
+    background: "color-mix(in srgb, var(--color-success), transparent 90%)",
     padding: "0.1em 0.3em",
     borderRadius: "3px",
     cursor: "pointer",
@@ -880,13 +879,13 @@ export const hybridRenderingTheme = EditorView.theme({
 
   ".cm-highlight": {
     background:
-      "linear-gradient(to bottom, rgba(255, 235, 59, 0.3), rgba(255, 235, 59, 0.4))",
+      "linear-gradient(to bottom, color-mix(in srgb, var(--color-warning), transparent 70%), color-mix(in srgb, var(--color-warning), transparent 60%))",
     padding: "0.1em 0.2em",
     borderRadius: "2px",
   },
 
   ".cm-comment": {
-    color: "#888",
+    color: "var(--color-text-tertiary)",
     opacity: "0.6",
     fontStyle: "italic",
   },

--- a/src/index.css
+++ b/src/index.css
@@ -125,7 +125,7 @@ span[class*="heading"],
   display: block;
   width: 100%;
   height: 0;
-  border-bottom: 2px solid rgba(127, 127, 127, 0.2);
+  border-bottom: 2px solid var(--color-border-primary);
   margin-top: 0.3em;
   margin-bottom: 0.5em;
 }
@@ -136,23 +136,12 @@ span[class*="heading"],
   display: block;
   width: 100%;
   height: 0;
-  border-bottom: 1px solid rgba(127, 127, 127, 0.15);
+  border-bottom: 1px solid var(--color-border-secondary);
   margin-top: 0.25em;
   margin-bottom: 0.4em;
 }
 
-/* Dark mode adjustments for heading dividers */
-.cm-editor.cm-focused .cm-line.cm-activeLine:has(.cm-heading-1)::after,
-.cm-editor.cm-focused
-  .cm-line.cm-activeLine:has(.cm-heading-text.cm-heading-1)::after {
-  border-bottom-color: rgba(200, 200, 200, 0.25);
-}
-
-.cm-editor.cm-focused .cm-line.cm-activeLine:has(.cm-heading-2)::after,
-.cm-editor.cm-focused
-  .cm-line.cm-activeLine:has(.cm-heading-text.cm-heading-2)::after {
-  border-bottom-color: rgba(200, 200, 200, 0.2);
-}
+/* Dark mode adjustments handled by CSS variables */
 
 /* CodeMirror Editor Styles */
 .cm-editor {
@@ -202,17 +191,17 @@ span[class*="heading"],
 }
 
 .cm-code-block-language {
-  background: rgba(128, 128, 128, 0.2);
+  background: var(--color-bg-secondary);
   padding: 0.25em 0.5em;
   font-size: 0.85em;
   font-family: monospace;
-  color: #888;
+  color: var(--color-text-tertiary);
 }
 
 /* Inline Code Styles */
 .cm-inline-code {
   font-family: "Monaco", "Menlo", "Ubuntu Mono", "Courier New", monospace;
-  background: rgba(128, 128, 128, 0.15);
+  background: var(--color-bg-secondary);
   padding: 0.1em 0.3em;
   border-radius: 3px;
   font-size: 0.9em;
@@ -220,13 +209,13 @@ span[class*="heading"],
 
 /* Link Styles */
 .cm-link-text {
-  color: #4dabf7;
+  color: var(--color-text-link);
   text-decoration: underline;
   cursor: pointer;
 }
 
 .cm-link-text:hover {
-  color: #339af0;
+  color: var(--color-accent);
 }
 
 /* Wiki Link Styles - NUCLEAR OPTION: Override all possible CodeMirror classes */
@@ -249,10 +238,10 @@ span.cm-wiki-link,
 
 /* Blockquote Styles */
 .cm-blockquote {
-  border-left: 3px solid #ccc;
+  border-left: 3px solid var(--color-border-primary);
   padding-left: 1em;
   margin-left: 0;
-  color: #666;
+  color: var(--color-text-secondary);
   font-style: italic;
 }
 
@@ -304,20 +293,20 @@ span.cm-wiki-link,
 .cm-dim-marker {
   opacity: 0.4 !important;
   font-size: 0.85em !important;
-  color: rgba(127, 127, 127, 0.6) !important;
+  color: var(--color-text-tertiary) !important;
   text-decoration: none !important;
   text-decoration-line: none !important;
   border-bottom: none !important;
 }
 
 .cm-link-url {
-  color: #4dabf7 !important;
+  color: var(--color-text-link) !important;
   opacity: 1;
 }
 
 .cm-link-url,
 .cm-link-url * {
-  color: #4dabf7 !important;
+  color: var(--color-text-link) !important;
 }
 
 /* Token spans inside markers can get their own generated classes (e.g. .c7) that re-apply underline.
@@ -349,7 +338,7 @@ span.cm-wiki-link,
 
   /* Make it easier to read against varying backgrounds */
   background: var(--color-surface, rgba(20, 20, 20, 0.95));
-  border: 1px solid rgba(127, 127, 127, 0.25);
+  border: 1px solid var(--color-border-primary);
   box-shadow: 0 12px 36px rgba(0, 0, 0, 0.35);
 
   /* Ensure the list doesn't get squeezed */
@@ -391,7 +380,7 @@ span.cm-wiki-link,
   .cm-tooltip-autocomplete
   > ul
   > li[aria-selected="true"] {
-  background: rgba(77, 171, 247, 0.18);
+  background: var(--color-interactive-selected);
 }
 
 .md-autocomplete-tooltip .cm-completionLabel {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -35,7 +35,7 @@ body {
   height: 100%;
   overflow: hidden;
   /* Use a non-transparent backdrop so the rounded app corners are visible */
-  background: #0b0c0f;
+  background: var(--color-bg-tertiary);
 }
 
 body {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -398,27 +398,27 @@
 }
 
 .alert-info {
-  background-color: rgba(66, 153, 225, 0.1);
-  border-color: rgba(66, 153, 225, 0.3);
-  color: #4299e1;
+  background-color: color-mix(in srgb, var(--color-text-link), transparent 90%);
+  border-color: color-mix(in srgb, var(--color-text-link), transparent 70%);
+  color: var(--color-text-link);
 }
 
 .alert-success {
-  background-color: rgba(72, 187, 120, 0.1);
-  border-color: rgba(72, 187, 120, 0.3);
-  color: #48bb78;
+  background-color: color-mix(in srgb, var(--color-success), transparent 90%);
+  border-color: color-mix(in srgb, var(--color-success), transparent 70%);
+  color: var(--color-success);
 }
 
 .alert-warning {
-  background-color: rgba(237, 137, 54, 0.1);
-  border-color: rgba(237, 137, 54, 0.3);
-  color: #ed8936;
+  background-color: color-mix(in srgb, var(--color-warning), transparent 90%);
+  border-color: color-mix(in srgb, var(--color-warning), transparent 70%);
+  color: var(--color-warning);
 }
 
 .alert-error {
-  background-color: rgba(245, 101, 101, 0.1);
-  border-color: rgba(245, 101, 101, 0.3);
-  color: #f56565;
+  background-color: color-mix(in srgb, var(--color-error), transparent 90%);
+  border-color: color-mix(in srgb, var(--color-error), transparent 70%);
+  color: var(--color-error);
 }
 
 /* ============================================================================

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -91,4 +91,9 @@
   --opacity-dimmed: 0.5;
   --opacity-hover: 0.6;
   --opacity-active: 0.85;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.1);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.2);
 }

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -15,18 +15,14 @@ export function showToast({
   type = "info",
   duration = 1500,
 }: ToastOptions) {
-  const isDark =
-    document.documentElement.getAttribute("data-mantine-color-scheme") ===
-    "dark";
-
   const getColor = () => {
     switch (type) {
       case "success":
-        return isDark ? "#51cf66" : "#37b24d";
+        return "var(--color-success)";
       case "error":
-        return isDark ? "#fa5252" : "#c92a2a";
+        return "var(--color-error)";
       default:
-        return isDark ? "#909296" : "#868e96";
+        return "var(--color-text-tertiary)";
     }
   };
 
@@ -38,9 +34,7 @@ export function showToast({
     withBorder: false,
     styles: {
       root: {
-        backgroundColor: isDark
-          ? "rgba(44, 46, 51, 0.95)"
-          : "rgba(241, 243, 245, 0.95)",
+        backgroundColor: "var(--color-bg-tertiary)",
         backdropFilter: "blur(8px)",
         border: "none",
         boxShadow: "none",


### PR DESCRIPTION
## Changes
- Replaced hardcoded hex colors with CSS variables (e.g. `var(--color-bg-tertiary)`, `var(--color-accent)`) in:
  - Settings components (`src/components/settings/`)
  - UI components (`SearchModal`, `HelpModal`, `CommandPalette`, etc.)
  - Editor styling (`createEditor.ts`, `hybridRendering.ts`, handlers)
  - CSS files (`index.css`, `styles/components.css`, `styles/base.css`)
- Added `--shadow-lg` to `variables.css`.
- Removed manual `isDark` logic where CSS variables handle theme switching automatically.

## Related Issue
#264