### PR TITLE
fix(editor): batch IPC calls for block refs (#254)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "oxinot"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "log",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -415,6 +415,7 @@ pub fn run() {
             commands::block::search_blocks,
             commands::block::resolve_block_path,
             commands::block::get_block,
+            commands::block::get_blocks,
             commands::block::get_block_ancestors,
             commands::block::get_block_subtree,
             // Page commands

--- a/src/utils/blockBatcher.ts
+++ b/src/utils/blockBatcher.ts
@@ -1,0 +1,115 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { BlockData } from "../stores/blockStore";
+import { useWorkspaceStore } from "../stores/workspaceStore";
+
+interface BlockBatcherOptions {
+  timeoutMs?: number;
+}
+
+class BlockBatcher {
+  private queue: string[] = [];
+  private pendingResolvers: Map<
+    string,
+    Array<(block: BlockData | null) => void>
+  > = new Map();
+  private cache: Map<string, BlockData> = new Map();
+  private timeoutId: ReturnType<typeof setTimeout> | null = null;
+  private timeoutMs: number;
+
+  constructor(options: BlockBatcherOptions = {}) {
+    this.timeoutMs = options.timeoutMs ?? 20; // 20ms debounce
+  }
+
+  public fetchBlock(blockId: string): Promise<BlockData | null> {
+    // 1. Check cache
+    const cached = this.cache.get(blockId);
+    if (cached) {
+      return Promise.resolve(cached);
+    }
+
+    // 2. Queue request
+    let resolvers = this.pendingResolvers.get(blockId);
+    if (!resolvers) {
+      this.queue.push(blockId);
+      resolvers = [];
+      this.pendingResolvers.set(blockId, resolvers);
+    }
+
+    return new Promise((resolve) => {
+      resolvers?.push(resolve);
+      this.scheduleFlush();
+    });
+  }
+
+  private scheduleFlush() {
+    if (this.timeoutId) return;
+
+    this.timeoutId = setTimeout(() => {
+      this.flush();
+      this.timeoutId = null;
+    }, this.timeoutMs);
+  }
+
+  private async flush() {
+    const idsToFetch = [...this.queue];
+    this.queue = [];
+
+    if (idsToFetch.length === 0) return;
+
+    try {
+      const workspacePath = useWorkspaceStore.getState().workspacePath;
+      if (!workspacePath) {
+        // If no workspace, we can't fetch. Resolve all with null.
+        throw new Error("No workspace selected");
+      }
+
+      // Backend 'get_blocks' returns Vec<Block> (BlockData[])
+      const blocks = await invoke<BlockData[]>("get_blocks", {
+        workspacePath,
+        request: { block_ids: idsToFetch },
+      });
+
+      // Populate cache and resolve
+      const blocksMap = new Map(blocks.map((b) => [b.id, b]));
+
+      for (const id of idsToFetch) {
+        const resolvers = this.pendingResolvers.get(id);
+        const block = blocksMap.get(id) ?? null;
+
+        if (block) {
+          this.cache.set(id, block);
+        }
+
+        if (resolvers) {
+          for (const resolve of resolvers) {
+            resolve(block);
+          }
+        }
+
+        this.pendingResolvers.delete(id);
+      }
+    } catch (error) {
+      console.warn("[BlockBatcher] Failed to batch fetch blocks", error);
+      // Reject all pending for this batch with null (graceful degradation)
+      for (const id of idsToFetch) {
+        const resolvers = this.pendingResolvers.get(id);
+        if (resolvers) {
+          for (const resolve of resolvers) {
+            resolve(null);
+          }
+        }
+        this.pendingResolvers.delete(id);
+      }
+    }
+  }
+
+  public clearCache() {
+    this.cache.clear();
+  }
+  
+  public invalidate(blockId: string) {
+    this.cache.delete(blockId);
+  }
+}
+
+export const blockBatcher = new BlockBatcher();


### PR DESCRIPTION
Fixes #254.

This PR implements batching and caching for block reference IPC calls to improve editor performance.

### Changes:
- **Backend**: Added `get_blocks` command to fetch multiple blocks in a single IPC call.
- **Frontend**: 
    - Implemented `BlockBatcher` utility that debounces multiple `fetchBlock` requests (20ms) into a single batched call.
    - Added simple caching in `BlockBatcher` to avoid redundant fetches.
    - Updated `BlockRefHandler` to use the batcher instead of direct `invoke`.