### PR TITLE
fix(store): improve tempId handling during rapid typing

### DIFF
--- a/src/hooks/useDebouncedBlockUpdate.ts
+++ b/src/hooks/useDebouncedBlockUpdate.ts
@@ -24,13 +24,22 @@ export function useDebouncedBlockUpdate(blockId: string) {
 
       timerRef.current = setTimeout(() => {
         if (pendingContentRef.current !== undefined) {
+          // Get current state to handle tempId -> realId mapping
+          const state = useBlockStore.getState();
+          let currentBlockId = blockIdRef.current;
+
+          // Check if the block has been mapped from tempId to realId
+          if (currentBlockId.startsWith("temp-")) {
+            const realId = state.tempIdMap[currentBlockId];
+            if (realId) {
+              currentBlockId = realId;
+            }
+          }
+
           // Access the current version of updateBlockContent
           const currentUpdateBlockContent =
             useBlockStore.getState().updateBlockContent;
-          currentUpdateBlockContent(
-            blockIdRef.current,
-            pendingContentRef.current
-          );
+          currentUpdateBlockContent(currentBlockId, pendingContentRef.current);
           pendingContentRef.current = undefined;
         }
       }, DEBOUNCE_MS);
@@ -44,9 +53,21 @@ export function useDebouncedBlockUpdate(blockId: string) {
       clearTimeout(timerRef.current);
     }
     if (pendingContentRef.current !== undefined) {
+      // Get current state to handle tempId -> realId mapping
+      const state = useBlockStore.getState();
+      let currentBlockId = blockIdRef.current;
+
+      // Check if the block has been mapped from tempId to realId
+      if (currentBlockId.startsWith("temp-")) {
+        const realId = state.tempIdMap[currentBlockId];
+        if (realId) {
+          currentBlockId = realId;
+        }
+      }
+
       const currentUpdateBlockContent =
         useBlockStore.getState().updateBlockContent;
-      currentUpdateBlockContent(blockIdRef.current, pendingContentRef.current);
+      currentUpdateBlockContent(currentBlockId, pendingContentRef.current);
       pendingContentRef.current = undefined;
     }
   }, []);


### PR DESCRIPTION
Improve handling of block creation with tempId to prevent failed update requests.

## Problem
When a new block is created with a tempId for immediate UI update, typing triggers auto-save before the real ID is returned from the backend. This causes update requests with the tempId to be sent to the backend, which fail.

## Solution
Implement a pending updates queue mechanism:
- Track pending content updates for tempId blocks
- When the real ID is returned, apply all pending updates
- Sync the latest content with the backend

## Changes
- Added tempIdMap for tempId -> realId tracking
- Added pendingUpdates queue in block store
- Updated createBlock to process pending updates after ID replacement
- Enhanced updateBlockContent to queue updates for tempId blocks
- Improved useDebouncedBlockUpdate to resolve tempId to realId

Closes #259