### PR TITLE
fix(editor): fix autocomplete keyboard navigation

### DIFF
--- a/src/editor/createEditor.ts
+++ b/src/editor/createEditor.ts
@@ -138,6 +138,10 @@ function createBasicExtensions(config: EditorConfig): Extension[] {
 
     // Keymaps (prepend user bindings so they override defaults)
     keymap.of([
+      // Autocomplete keymap (Enter, Arrows, Esc) must take precedence over
+      // outliner keybindings so the dropdown can be navigated when open.
+      ...completionKeymap,
+
       ...(config.keybindings ?? []),
 
       // Force insert Space to bypass any blockers (completion keymap, IME artifacts, etc)
@@ -268,7 +272,6 @@ function createBasicExtensions(config: EditorConfig): Extension[] {
       ...historyKeymap,
       ...closeBracketsKeymap,
       ...searchKeymap,
-      ...completionKeymap,
     ])
   );
 


### PR DESCRIPTION
Fix autocomplete dropdown keyboard navigation by prioritizing the completion keymap.

When the autocomplete dropdown is open, Enter, ArrowUp/Down, and Escape will now be handled by the dropdown instead of falling through to the outliner block actions (like splitting blocks or navigating between blocks).

Closes #301