### PR TITLE
improve(ui): replace inline hover styles with CSS :hover in SubPagesSection

### DIFF
--- a/src/components/SubPagesSection.css
+++ b/src/components/SubPagesSection.css
@@ -1,0 +1,59 @@
+.subpages-container {
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--color-border-primary);
+}
+
+.subpages-header {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin-bottom: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.subpages-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.page-tree-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
+}
+
+.page-tree-item:hover {
+  background-color: var(--color-interactive-hover);
+}
+
+.page-tree-item-toggle {
+  width: 16px;
+  flex-shrink: 0;
+}
+
+.page-tree-item-title {
+  font-size: 15px;
+  color: var(--color-text-primary);
+  font-weight: 400;
+  user-select: none;
+  cursor: pointer;
+  border: none;
+  background: none;
+  padding: 0;
+}
+
+.page-tree-item-title.directory {
+  font-weight: 500;
+}
+
+.page-tree-children {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/components/SubPagesSection.tsx
+++ b/src/components/SubPagesSection.tsx
@@ -1,10 +1,10 @@
-import { useComputedColorScheme } from "@mantine/core";
 import { useMemo, useState } from "react";
 import { useBlockStore } from "../stores/blockStore";
 import { usePageStore } from "../stores/pageStore";
 import { useViewStore } from "../stores/viewStore";
 import { BulletPoint } from "./common/BulletPoint";
 import { CollapseToggle } from "./common/CollapseToggle";
+import "./SubPagesSection.css";
 
 interface SubPagesSectionProps {
   currentPageId: string;
@@ -18,9 +18,6 @@ interface PageTreeNode {
 }
 
 export function SubPagesSection({ currentPageId }: SubPagesSectionProps) {
-  const computedColorScheme = useComputedColorScheme("light");
-  const isDark = computedColorScheme === "dark";
-
   const pagesById = usePageStore((state) => state.pagesById);
   const pageIds = usePageStore((state) => state.pageIds);
   const { openNote } = useViewStore();
@@ -96,24 +93,9 @@ export function SubPagesSection({ currentPageId }: SubPagesSectionProps) {
       return (
         <div key={node.id}>
           <div
+            className="page-tree-item"
             style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "8px",
               paddingLeft: `${depth * 24}px`,
-              paddingTop: "4px",
-              paddingBottom: "4px",
-              cursor: "pointer",
-              borderRadius: "4px",
-              transition: "background-color 0.15s ease",
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.backgroundColor = isDark
-                ? "rgba(255, 255, 255, 0.05)"
-                : "rgba(0, 0, 0, 0.03)";
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.backgroundColor = "transparent";
             }}
           >
             {/* Collapse toggle */}
@@ -126,7 +108,7 @@ export function SubPagesSection({ currentPageId }: SubPagesSectionProps) {
                 }}
               />
             ) : (
-              <div style={{ width: "16px", flexShrink: 0 }} />
+              <div className="page-tree-item-toggle" />
             )}
 
             {/* Bullet point */}
@@ -136,18 +118,9 @@ export function SubPagesSection({ currentPageId }: SubPagesSectionProps) {
             <button
               type="button"
               onClick={() => handlePageClick(node.id)}
-              style={{
-                fontSize: "15px",
-                color: isDark
-                  ? "rgba(255, 255, 255, 0.85)"
-                  : "rgba(0, 0, 0, 0.85)",
-                fontWeight: node.isDirectory ? 500 : 400,
-                userSelect: "none",
-                cursor: "pointer",
-                border: "none",
-                background: "none",
-                padding: "0",
-              }}
+              className={`page-tree-item-title ${
+                node.isDirectory ? "directory" : ""
+              }`}
             >
               {node.title}
             </button>
@@ -155,7 +128,9 @@ export function SubPagesSection({ currentPageId }: SubPagesSectionProps) {
 
           {/* Render children recursively */}
           {hasChildren && !isCollapsed && (
-            <div>{renderPageTree(node.children, depth + 1)}</div>
+            <div className="page-tree-children">
+              {renderPageTree(node.children, depth + 1)}
+            </div>
           )}
         </div>
       );
@@ -167,35 +142,10 @@ export function SubPagesSection({ currentPageId }: SubPagesSectionProps) {
   }
 
   return (
-    <div
-      style={{
-        marginTop: "48px",
-        paddingTop: "24px",
-        borderTop: `1px solid ${isDark ? "rgba(255, 255, 255, 0.1)" : "rgba(0, 0, 0, 0.1)"}`,
-      }}
-    >
-      <div
-        style={{
-          fontSize: "13px",
-          fontWeight: 600,
-          color: isDark ? "rgba(255, 255, 255, 0.5)" : "rgba(0, 0, 0, 0.5)",
-          marginBottom: "12px",
-          textTransform: "uppercase",
-          letterSpacing: "0.5px",
-        }}
-      >
-        Subpages
-      </div>
+    <div className="subpages-container">
+      <div className="subpages-header">Subpages</div>
 
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: "2px",
-        }}
-      >
-        {renderPageTree(childPages)}
-      </div>
+      <div className="subpages-list">{renderPageTree(childPages)}</div>
     </div>
   );
 }


### PR DESCRIPTION
Replace imperative onMouseEnter/Leave handlers with declarative CSS :hover styles.

## Changes

### Before
- Inline style manipulation via onMouseEnter/Leave handlers
- Color scheme checks in component logic
- Theme changes required state updates

### After
- CSS :hover pseudo-class for hover effects
- Design system CSS variables for colors
- Theme changes automatically propagate via CSS

## Benefits
✅ Follows React declarative paradigm  
✅ Automatic theme synchronization via CSS variables  
✅ Cleaner component code (removed handlers)  
✅ Better CSS reusability  
✅ Improved performance (no runtime DOM manipulation)  
✅ Removed useComputedColorScheme dependency  

## CSS Variables Used
- `var(--color-interactive-hover)` - Hover background
- `var(--color-text-primary)` - Primary text color
- `var(--color-text-secondary)` - Secondary text color
- `var(--color-border-primary)` - Primary border color

Closes #263