### PR TITLE
refactor: use constant for indentation size

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "oxinot"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "log",

--- a/src/components/SubPagesSection.tsx
+++ b/src/components/SubPagesSection.tsx
@@ -5,6 +5,7 @@ import { useViewStore } from "../stores/viewStore";
 import { BulletPoint } from "./common/BulletPoint";
 import { CollapseToggle } from "./common/CollapseToggle";
 import "./SubPagesSection.css";
+import { INDENT_PER_LEVEL } from "../constants/layout";
 
 interface SubPagesSectionProps {
   currentPageId: string;
@@ -95,7 +96,7 @@ export function SubPagesSection({ currentPageId }: SubPagesSectionProps) {
           <div
             className="page-tree-item"
             style={{
-              paddingLeft: `${depth * 24}px`,
+              paddingLeft: `${depth * INDENT_PER_LEVEL}px`,
             }}
           >
             {/* Collapse toggle */}

--- a/src/components/common/IndentGuide.tsx
+++ b/src/components/common/IndentGuide.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "react";
+import { INDENT_PER_LEVEL } from "../../constants/layout";
 
 interface IndentGuideProps {
   depth: number;
@@ -13,7 +14,7 @@ interface IndentGuideProps {
  * Displays a single vertical line for the current indentation level.
  *
  * Calculation:
- * - Each item has: paddingLeft = depth * 24px
+ * - Each item has: paddingLeft = depth * INDENT_PER_LEVEL
  * - Inside padding: collapse-toggle (20px) + gap (8px) + bullet-container (24px, center at 12px)
  * - Bullet center for depth 0: 0 + 20 + 8 + 12 = 40px
  * - Bullet center for depth 1: 24 + 20 + 8 + 12 = 64px
@@ -23,7 +24,7 @@ interface IndentGuideProps {
  */
 export function IndentGuide({
   depth,
-  indentSize = 24,
+  indentSize = INDENT_PER_LEVEL,
   show = true,
   className = "",
   style,

--- a/src/components/fileTree/NewPageInput.tsx
+++ b/src/components/fileTree/NewPageInput.tsx
@@ -1,6 +1,7 @@
 import { TextInput } from "@mantine/core";
 import { useEffect, useRef, useState } from "react";
 import { BulletPoint } from "../common/BulletPoint";
+import { INDENT_PER_LEVEL } from "../../constants/layout";
 
 interface NewPageInputProps {
   depth: number;
@@ -67,7 +68,7 @@ export function NewPageInput({
         display: "flex",
         alignItems: "center",
         gap: "var(--spacing-sm)",
-        paddingLeft: `${depth * 24}px`,
+        paddingLeft: `${depth * INDENT_PER_LEVEL}px`,
         paddingTop: "2px",
         paddingBottom: "2px",
         position: "relative",

--- a/src/components/fileTree/PageTreeItem.tsx
+++ b/src/components/fileTree/PageTreeItem.tsx
@@ -15,6 +15,7 @@ import { CollapseToggle } from "../common/CollapseToggle";
 import { IndentGuide } from "../common/IndentGuide";
 import { ContextMenu, type ContextMenuSection } from "../common/ContextMenu";
 import { useTranslation } from "react-i18next";
+import { INDENT_PER_LEVEL } from "../../constants/layout";
 
 // Extract basename from path (e.g., "A/B/C" -> "C")
 function getPageBasename(title: string): string {
@@ -201,7 +202,7 @@ export function PageTreeItem({
             <div
               style={{
                 position: "absolute",
-                left: `${depth * 24}px`,
+                left: `${depth * INDENT_PER_LEVEL}px`,
                 right: 0,
                 top: 0,
                 bottom: 0,
@@ -226,7 +227,7 @@ export function PageTreeItem({
               transition: "background-color var(--transition-normal)",
               userSelect: "none",
               zIndex: 2,
-              marginLeft: `${depth * 24}px`,
+              marginLeft: `${depth * INDENT_PER_LEVEL}px`,
             }}
           >
             {/* Collapse/Expand Toggle */}

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -48,9 +48,11 @@ export const BLOCK_LAYOUT = {
 /**
  * File tree layout values
  */
+export const INDENT_PER_LEVEL = 24;
+
 export const FILE_TREE_LAYOUT = {
   /** Indent per nesting level */
-  indentSize: "24px",
+  indentSize: `${INDENT_PER_LEVEL}px`,
   /** Item height */
   itemHeight: "28px",
   /** Icon size */

--- a/src/outliner/BlockComponent.tsx
+++ b/src/outliner/BlockComponent.tsx
@@ -24,6 +24,7 @@ import { useBlockUIStore } from "../stores/blockUIStore";
 import { useViewStore } from "../stores/viewStore";
 import { MacroContentWrapper } from "./MacroContentWrapper";
 import "./BlockComponent.css";
+import { INDENT_PER_LEVEL } from "../constants/layout";
 
 interface BlockComponentProps {
   blockId: string;
@@ -708,7 +709,7 @@ export const BlockComponent: React.FC<BlockComponentProps> = memo(
         <div
           className="indent-guide"
           style={{
-            left: `${depth * 24 + 18}px`, // Align with collapse toggle center (20px width / 2 + 4px margin)
+            left: `${depth * INDENT_PER_LEVEL + 18}px`, // Align with collapse toggle center (20px width / 2 + 4px margin)
           }}
         />
       ) : null;
@@ -740,7 +741,7 @@ export const BlockComponent: React.FC<BlockComponentProps> = memo(
           }}
         >
           {indentGuide}
-          <div className="block-row" style={{ paddingLeft: `${depth * 24}px` }}>
+          <div className="block-row" style={{ paddingLeft: `${depth * INDENT_PER_LEVEL}px` }}>
             {/* Collapse/Expand Toggle */}
             {hasChildren ? (
               <button


### PR DESCRIPTION
Replaced hardcoded '24' with INDENT_PER_LEVEL constant from src/constants/layout.ts.

Resolves #353