### PR TITLE
Improve: CSS 변수 및 z-index 관리 구조 개선

### DIFF
--- a/src/components/common/common.css
+++ b/src/components/common/common.css
@@ -16,7 +16,7 @@
   transition: opacity var(--transition-normal), background-color var(--transition-normal);
   border-radius: var(--radius-sm);
   position: relative;
-  z-index: 1;
+  z-index: var(--z-index-low);
 }
 
 .collapse-toggle.collapsed {

--- a/src/index.css
+++ b/src/index.css
@@ -325,7 +325,7 @@ span.cm-wiki-link,
    - Do NOT force fixed positioning (it breaks placement and can pin the panel to top-left). */
 .md-autocomplete-tooltip {
   /* High enough to float over editor/content, but let app-level overlays win if needed */
-  z-index: 2000;
+  z-index: var(--z-index-toast);
 
   /* Keep CM positioning (usually absolute) */
   position: static;

--- a/src/outliner/BlockComponent.css
+++ b/src/outliner/BlockComponent.css
@@ -18,7 +18,7 @@
   width: 1px;
   background-color: var(--color-indent-guide);
   pointer-events: none;
-  z-index: 0;
+  z-index: var(--z-index-base);
 }
 
 .block-row {
@@ -54,7 +54,7 @@
     background-color var(--transition-normal);
   border-radius: var(--radius-sm);
   position: relative;
-  z-index: 1;
+  z-index: var(--z-index-low);
 }
 
 .block-row:hover .collapse-toggle {

--- a/src/outliner/BlockEditor.css
+++ b/src/outliner/BlockEditor.css
@@ -80,7 +80,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  z-index: 10;
+  z-index: var(--z-index-elevated);
 }
 
 .block-bullet {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -170,7 +170,7 @@
 
 .tooltip {
   position: absolute;
-  z-index: 1070;
+  z-index: var(--z-index-tooltip);
   padding: var(--spacing-xs) var(--spacing-sm);
   font-size: var(--font-size-xs);
   line-height: var(--line-height-normal);
@@ -198,7 +198,7 @@
 
 .dropdown-menu {
   position: absolute;
-  z-index: 1000;
+  z-index: var(--z-index-dropdown);
   min-width: 160px;
   padding: var(--spacing-xs) 0;
   margin-top: var(--spacing-xs);
@@ -258,8 +258,8 @@
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 1040;
-  background-color: rgba(0, 0, 0, 0.6);
+  z-index: var(--z-index-backdrop);
+  background-color: var(--color-bg-overlay);
   backdrop-filter: blur(4px);
   opacity: 0;
   transition: opacity var(--transition-normal);
@@ -274,7 +274,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 1050;
+  z-index: var(--z-index-modal);
   width: 90%;
   max-width: 600px;
   max-height: 90vh;

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -88,6 +88,7 @@ function ThemeSynchronizer({ children }: { children: ReactNode }) {
     setCssVariables(root, "--layout", appTheme.layout);
     setCssVariables(root, "--transition", appTheme.transitions);
     setCssVariables(root, "--opacity", appTheme.opacity);
+    setCssVariables(root, "--z-index", appTheme.zIndex);
   }, [appTheme, camelToKebab]);
 
   return (

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -59,6 +59,7 @@ export function createColorPalette(
         secondary: "#1a1a1d",
         tertiary: "#3a3a42",
         elevated: "#2a2a30",
+        overlay: "rgba(0, 0, 0, 0.6)",
       },
       text: {
         primary: "#f0f0f2",
@@ -96,6 +97,7 @@ export function createColorPalette(
       secondary: "#f9f9fb",
       tertiary: "#f5f5f8",
       elevated: "#efefef",
+      overlay: "rgba(0, 0, 0, 0.6)",
     },
     text: {
       primary: "#1a1a1a",

--- a/src/theme/schema.ts
+++ b/src/theme/schema.ts
@@ -29,6 +29,20 @@ export interface Opacity {
   active: string;
 }
 
+export interface ZIndex {
+  [key: string]: unknown;
+  base: number;
+  low: number;
+  elevated: number;
+  dropdown: number;
+  sticky: number;
+  backdrop: number;
+  modal: number;
+  popover: number;
+  tooltip: number;
+  toast: number;
+}
+
 export interface AppTheme {
   name: string;
   scheme: ColorScheme;
@@ -40,5 +54,6 @@ export interface AppTheme {
   layout: Layout;
   transitions: Transitions;
   opacity: Opacity;
+  zIndex: ZIndex;
   // TODO: Add shadows if they need to be theme-specific
 }

--- a/src/theme/themes.ts
+++ b/src/theme/themes.ts
@@ -6,6 +6,7 @@ import {
   LAYOUT,
   TRANSITIONS,
   OPACITY,
+  Z_INDEX,
 } from "./tokens";
 import { createColorPalette } from "./colors"; // Assuming this helps generate ColorPalette
 
@@ -26,6 +27,7 @@ export const createTheme = (
     layout: LAYOUT,
     transitions: TRANSITIONS,
     opacity: OPACITY,
+    zIndex: Z_INDEX,
   };
 };
 

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -55,3 +55,16 @@ export const OPACITY = {
   hover: "0.6",
   active: "0.85",
 } as const;
+
+export const Z_INDEX = {
+  base: 0,
+  low: 1,
+  elevated: 10,
+  dropdown: 1000,
+  sticky: 1020,
+  backdrop: 1040,
+  modal: 1050,
+  popover: 1060,
+  tooltip: 1070,
+  toast: 2000,
+} as const;

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -18,6 +18,7 @@ export interface ColorPalette {
     secondary: string;
     tertiary: string;
     elevated: string;
+    overlay: string;
   };
 
   // Text colors


### PR DESCRIPTION
## 구현 상세
- `src/theme/tokens.ts`에 `Z_INDEX` 토큰 추가 (base, low, elevated, dropdown, sticky, backdrop, modal, popover, tooltip, toast)
- `src/theme/schema.ts`, `src/theme/themes.ts`, `src/theme/ThemeProvider.tsx` 업데이트하여 z-index CSS 변수 주입 (`--z-index-*`)
- `src/styles/components.css`, `src/index.css`, `src/outliner/BlockEditor.css`, `src/outliner/BlockComponent.css`, `src/components/common/common.css`에서 하드코딩된 z-index 값을 변수로 대체
- `src/theme/colors.ts`에 `overlay` 색상 추가 및 `src/styles/components.css`의 모달 백드롭에 적용

## 이슈
Closes #338