### PR TITLE
refactor: improve common component styles with css modules

### DIFF
--- a/src/components/common/CollapseToggle.module.css
+++ b/src/components/common/CollapseToggle.module.css
@@ -1,5 +1,4 @@
-/* CollapseToggle Component */
-.collapse-toggle {
+.toggle {
   flex-shrink: 0;
   width: var(--layout-collapse-toggle-size);
   height: var(--layout-collapse-toggle-size);
@@ -19,27 +18,27 @@
   z-index: 1;
 }
 
-.collapse-toggle.collapsed {
+.collapsed {
   opacity: var(--opacity-disabled);
 }
 
-.collapse-toggle.expanded {
+.expanded {
   opacity: 0;
 }
 
-.collapse-toggle:hover {
+.toggle:hover {
   opacity: 1;
   background-color: var(--color-interactive-hover);
 }
 
-.collapse-toggle svg {
+.toggle svg {
   transition: transform var(--transition-normal);
 }
 
-.collapse-toggle.collapsed svg {
+.collapsed svg {
   transform: rotate(0deg);
 }
 
-.collapse-toggle.expanded svg {
+.expanded svg {
   transform: rotate(90deg);
 }

--- a/src/components/common/CollapseToggle.tsx
+++ b/src/components/common/CollapseToggle.tsx
@@ -1,7 +1,7 @@
 import { IconChevronRight } from "@tabler/icons-react";
 import { useTranslation } from "react-i18next";
 import type { CSSProperties } from "react";
-import "./common.css";
+import styles from "./CollapseToggle.module.css";
 
 interface CollapseToggleProps {
   isCollapsed: boolean;
@@ -25,8 +25,8 @@ export function CollapseToggle({
   return (
     <button
       type="button"
-      className={`collapse-toggle ${
-        isCollapsed ? "collapsed" : "expanded"
+      className={`${styles.toggle} ${
+        isCollapsed ? styles.collapsed : styles.expanded
       } ${className}`}
       onClick={onClick}
       style={style}

--- a/src/components/common/IndentGuide.module.css
+++ b/src/components/common/IndentGuide.module.css
@@ -1,0 +1,9 @@
+.indentGuide {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background-color: var(--color-indent-guide);
+  pointer-events: none;
+  z-index: 0;
+}

--- a/src/components/common/IndentGuide.tsx
+++ b/src/components/common/IndentGuide.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import { INDENT_PER_LEVEL } from "../../constants/layout";
+import styles from "./IndentGuide.module.css";
 
 interface IndentGuideProps {
   depth: number;
@@ -38,16 +39,9 @@ export function IndentGuide({
 
   return (
     <div
-      className={`indent-guide ${className}`}
+      className={`${styles.indentGuide} ${className}`}
       style={{
-        position: "absolute",
         left: `${leftPosition}px`,
-        top: 0,
-        bottom: 0,
-        width: "1px",
-        backgroundColor: "var(--color-indent-guide)",
-        pointerEvents: "none",
-        zIndex: 0,
         ...style,
       }}
     />


### PR DESCRIPTION
Refactored IndentGuide and CollapseToggle to use CSS modules for better style isolation and maintainability.
Removed legacy common.css.
Ensured consistency with theme variables.

Resolves #356