### PR TITLE
improve(async): migrate file I/O to tokio::fs for non-blocking async operations

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2563,6 +2563,7 @@ dependencies = [
 name = "oxinot"
 version = "0.15.0"
 dependencies = [
+ "async-recursion",
  "chrono",
  "log",
  "rand 0.8.5",
@@ -2579,6 +2580,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-updater",
  "thiserror 1.0.69",
+ "tokio",
  "uuid",
  "walkdir",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,3 +35,5 @@ tauri-plugin-process = "2"
 regex = "1.12.2"
 thiserror = "1.0"
 rand = "0.8"
+tokio = { version = "1.49.0", features = ["fs", "io-util", "process"] }
+async-recursion = "1.1.1"


### PR DESCRIPTION
## Overview
Implement tokio::fs migration to enable non-blocking async file I/O throughout the codebase.

## Changes
- Replace std::fs with tokio::fs in lib.rs for all file operations
- Convert FileSyncService methods to async (create_page_file, rename_page_file, move_page_file, delete_page_file, convert_page_to_directory, convert_directory_to_file)
- Update path_validator.rs to use std::fs::canonicalize (sync) to avoid Send trait issues
- Convert page_sync.rs functions to async with proper await handling
- Fix borrowing issues in block.rs and page_sync.rs query operations
- Update command handlers and Tauri invocations for async compatibility

## Benefits
- Improved concurrency with non-blocking file I/O
- Better resource utilization through async/await
- Reduced thread contention in high-load scenarios
- Foundation for future async-based optimizations

## Testing
- ✅ Compiles successfully with cargo check
- ✅ No clippy warnings
- Ready for integration testing

Closes #399