### PR TITLE
fix(tree): restore page tree drag-and-drop functionality

### DIFF
--- a/src/components/fileTree/PageTreeItem.tsx
+++ b/src/components/fileTree/PageTreeItem.tsx
@@ -1,4 +1,10 @@
-import { ActionIcon, Group, Text, TextInput, UnstyledButton } from "@mantine/core";
+import {
+  ActionIcon,
+  Group,
+  Text,
+  TextInput,
+  UnstyledButton,
+} from "@mantine/core";
 import {
   IconCheck,
   IconEdit,
@@ -222,7 +228,14 @@ export function PageTreeItem({
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
           onMouseDown={(e) => {
+            console.log("[PageTreeItem] onMouseDown triggered", {
+              pageId: page.id,
+              button: e.button,
+              isEditing,
+              target: (e.target as HTMLElement).tagName,
+            });
             if (!isEditing && e.button === 0) {
+              console.log("[PageTreeItem] Calling onMouseDown handler");
               onMouseDown(e, page.id);
             }
           }}
@@ -268,26 +281,30 @@ export function PageTreeItem({
             }}
           >
             {/* Collapse/Expand Toggle */}
-            <CollapseToggle
-              isCollapsed={isCollapsed}
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggleCollapse(page.id);
-              }}
-              style={{
-                opacity: hasChildren
-                  ? isCollapsed
-                    ? "var(--opacity-disabled)"
-                    : isHovered
-                    ? "var(--opacity-dimmed)"
-                    : 0
-                  : 0,
-                visibility: hasChildren ? "visible" : "hidden",
-              }}
-            />
+            <div data-action-button="true">
+              <CollapseToggle
+                isCollapsed={isCollapsed}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleCollapse(page.id);
+                }}
+                style={{
+                  opacity: hasChildren
+                    ? isCollapsed
+                      ? "var(--opacity-disabled)"
+                      : isHovered
+                      ? "var(--opacity-dimmed)"
+                      : 0
+                    : 0,
+                  visibility: hasChildren ? "visible" : "hidden",
+                }}
+              />
+            </div>
 
             {/* Bullet Point */}
-            <BulletPoint onClick={handleBulletClick} />
+            <div data-action-button="true">
+              <BulletPoint onClick={handleBulletClick} />
+            </div>
 
             {/* Page Title or Edit Input */}
             {isEditing ? (
@@ -392,6 +409,7 @@ export function PageTreeItem({
                         onAddChild(page.id);
                       }}
                       title="Add child page"
+                      data-action-button="true"
                     >
                       <IconFolderPlus size={14} />
                     </ActionIcon>
@@ -403,6 +421,7 @@ export function PageTreeItem({
                         onEdit(page.id);
                       }}
                       title="Rename"
+                      data-action-button="true"
                     >
                       <IconEdit size={14} />
                     </ActionIcon>
@@ -423,6 +442,7 @@ export function PageTreeItem({
                         onDelete(page.id);
                       }}
                       title="Delete"
+                      data-action-button="true"
                     >
                       <IconX size={14} />
                     </ActionIcon>


### PR DESCRIPTION
## 개요
Page tree에서 드래그 앤 드롭이 작동하지 않는 문제를 수정했습니다.

## 변경 사항
- **FileTreeIndex.tsx**: useRef를 사용하여 이벤트 핸들러를 안정화
- **PageTreeItem.tsx**: 액션 버튼에 data-action-button 속성 추가하여 드래그 방지

## 주요 수정 내용
1. **이벤트 리스너 안정화**
   - useRef를 사용하여 pages, movePage, loadPages의 최신 값 유지
   - useCallback으로 handleMouseMove와 handleMouseUp을 메모이제이션
   - useEffect 의존성 배열 최적화

2. **드래그 시작 로직 개선**
   - 페이지 타이틀 영역에서 드래그 가능하도록 수정
   - 액션 버튼(추가, 편집, 삭제)은 드래그 시작 방지
   - data-action-button 속성으로 클릭 가능한 요소 구분

3. **디버그 로깅 추가**
   - 드래그 이벤트 추적을 위한 콘솔 로그 추가

## 테스트
- [x] 빌드 성공 확인
- [x] Lint 통과 확인
- [ ] 실제 드래그 앤 드롭 동작 테스트 필요

Closes #443