### PR TITLE
fix(workspace): load pages after opening workspace to fix missing content

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "oxinot"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-recursion",
  "chrono",

--- a/src/components/FileTreeIndex.tsx
+++ b/src/components/FileTreeIndex.tsx
@@ -1,6 +1,7 @@
 import { Button, Group, Modal, Stack, Text } from "@mantine/core";
 import { IconPlus } from "@tabler/icons-react";
-import React, {
+import type React from "react";
+import {
   useEffect,
   useState,
   useCallback,

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -113,6 +113,9 @@ export const useWorkspaceStore = createWithEqualityFn<WorkspaceState>()(
             fileTree: items,
             workspaces,
           });
+
+          // Load pages after opening workspace
+          await usePageStore.getState().loadPages();
         } catch (err) {
           const errorMessage =
             err instanceof Error ? err.message : "Failed to open workspace";


### PR DESCRIPTION
Closes #454

When selecting an already-open workspace, the pages were not being reloaded after clearPages() was called. This resulted in 'No page selected' message instead of showing the content.

The fix adds an explicit loadPages() call in openWorkspace() after clearing the store, ensuring pages are loaded whenever a workspace is opened regardless of whether it was already open.