### PR TITLE
fix(subpages): make entire subpage item clickable

### DIFF
--- a/src/components/SubPagesSection.css
+++ b/src/components/SubPagesSection.css
@@ -23,10 +23,15 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 0;
+  padding: 4px 8px;
   cursor: pointer;
   border-radius: 4px;
   transition: background-color 0.15s ease;
+  margin: 0 -8px;
+  width: 100%;
+  border: none;
+  background: none;
+  text-align: left;
 }
 
 .page-tree-item:hover {
@@ -43,10 +48,8 @@
   color: var(--color-text-primary);
   font-weight: 400;
   user-select: none;
-  cursor: pointer;
-  border: none;
-  background: none;
   padding: 0;
+  flex: 1;
 }
 
 .page-tree-item-title.directory {

--- a/src/components/SubPagesSection.tsx
+++ b/src/components/SubPagesSection.tsx
@@ -93,11 +93,13 @@ export function SubPagesSection({ currentPageId }: SubPagesSectionProps) {
 
       return (
         <div key={node.id}>
-          <div
+          <button
+            type="button"
             className="page-tree-item"
             style={{
               paddingLeft: `${depth * INDENT_PER_LEVEL}px`,
             }}
+            onClick={() => handlePageClick(node.id)}
           >
             {/* Collapse toggle */}
             {hasChildren ? (
@@ -116,16 +118,14 @@ export function SubPagesSection({ currentPageId }: SubPagesSectionProps) {
             <BulletPoint type="default" />
 
             {/* Title */}
-            <button
-              type="button"
-              onClick={() => handlePageClick(node.id)}
+            <div
               className={`page-tree-item-title ${
                 node.isDirectory ? "directory" : ""
               }`}
             >
               {node.title}
-            </button>
-          </div>
+            </div>
+          </button>
 
           {/* Render children recursively */}
           {hasChildren && !isCollapsed && (


### PR DESCRIPTION
Make the entire subpage item clickable instead of just the title text.

Changed the page-tree-item from a div to a button element for:
- Better usability: users can click anywhere on the item
- Improved accessibility: semantic button element with keyboard support
- Consistent behavior: works across all parts of the item (bullet, spacing, text)