### PR TITLE
fix(security): update CSP to allow Firebase and analytics

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -55,7 +55,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' asset: https: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self'; connect-src 'self' https://github.com ipc://; font-src 'self' data: https://fonts.gstatic.com;"
+      "csp": "default-src 'self'; img-src 'self' asset: https: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' https://www.googletagmanager.com; connect-src 'self' https://github.com https://firebase.googleapis.com https://firebaseinstallations.googleapis.com https://www.googletagmanager.com ipc://; font-src 'self' data: https://fonts.gstatic.com;"
     },
     "withGlobalTauri": false
   }


### PR DESCRIPTION
## 문제
릴리즈된 앱에서 발생하는 CSP 에러들:
- Firebase 요청 차단 (firebase.googleapis.com, firebaseinstallations.googleapis.com)
- Google Analytics/Tag Manager 차단 (googletagmanager.com)
- Tauri IPC 커스텀 프로토콜 차단

## 해결책
tauri.conf.json의 CSP를 업데이트하여 필요한 외부 서비스를 허용:

**추가된 connect-src:**
- https://firebase.googleapis.com
- https://firebaseinstallations.googleapis.com
- https://www.googletagmanager.com

**추가된 script-src:**
- https://www.googletagmanager.com

## 테스트
- [ ] 빌드 성공 확인
- [ ] 릴리즈 앱에서 CSP 에러 없음 확인
- [ ] Firebase 분석 정상 작동 확인
- [ ] 자동 업데이트 정상 작동 확인