### PR TITLE
feat(ai): Add AI Settings Store & UI

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -18,6 +18,7 @@ import {
   IconLanguage,
   IconList,
   IconPalette,
+  IconRobot,
   IconSearch,
   IconSettings,
   IconX,
@@ -34,6 +35,7 @@ import { useOutlinerSettingsStore } from "../stores/outlinerSettingsStore";
 import { type FontFamily, useThemeStore } from "../stores/themeStore";
 import { AboutSettings } from "./settings/AboutSettings";
 import { AdvancedSettings } from "./settings/AdvancedSettings";
+import { AISettings } from "./settings/AISettings";
 import { AppearanceSettings } from "./settings/AppearanceSettings";
 import { DailyNotesSettings } from "./settings/DailyNotesSettings";
 import { DatetimeSettings } from "./settings/DatetimeSettings";
@@ -485,6 +487,24 @@ export function SettingsModal({
           "toggle",
         ],
         component: <ShortcutsSettings matchesSearch={matchesSearch} />,
+      },
+      {
+        id: "ai",
+        icon: <IconRobot size={16} />,
+        labelKey: "settings.tabs.ai",
+        keywords: [
+          t("settings.ai.title"),
+          "copilot",
+          "gpt",
+          "gemini",
+          "claude",
+          "ollama",
+          "chat",
+          "model",
+          "api key",
+          "artificial intelligence",
+        ],
+        component: <AISettings matchesSearch={matchesSearch} />,
       },
       {
         id: "advanced",

--- a/src/components/settings/AISettings.tsx
+++ b/src/components/settings/AISettings.tsx
@@ -1,0 +1,229 @@
+import {
+  ActionIcon,
+  Button,
+  Card,
+  Group,
+  PasswordInput,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+  Textarea,
+  Tooltip,
+} from "@mantine/core";
+import { IconPlus, IconTrash, IconPencil, IconCheck, IconX } from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
+import { useState } from "react";
+import { useAISettingsStore, type AIProvider, type PromptTemplate } from "../../stores/aiSettingsStore";
+
+interface AISettingsProps {
+  matchesSearch: (text: string) => boolean;
+}
+
+export function AISettings({ matchesSearch }: AISettingsProps) {
+  const { t } = useTranslation();
+  
+  const provider = useAISettingsStore((state) => state.provider);
+  const apiKey = useAISettingsStore((state) => state.apiKey);
+  const baseUrl = useAISettingsStore((state) => state.baseUrl);
+  const model = useAISettingsStore((state) => state.model);
+  const promptTemplates = useAISettingsStore((state) => state.promptTemplates);
+
+  const setProvider = useAISettingsStore((state) => state.setProvider);
+  const setApiKey = useAISettingsStore((state) => state.setApiKey);
+  const setBaseUrl = useAISettingsStore((state) => state.setBaseUrl);
+  const setModel = useAISettingsStore((state) => state.setModel);
+  const addPromptTemplate = useAISettingsStore((state) => state.addPromptTemplate);
+  const updatePromptTemplate = useAISettingsStore((state) => state.updatePromptTemplate);
+  const deletePromptTemplate = useAISettingsStore((state) => state.deletePromptTemplate);
+
+  const [newTemplateName, setNewTemplateName] = useState("");
+  const [newTemplateContent, setNewTemplateContent] = useState("");
+  const [editingTemplateId, setEditingTemplateId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editContent, setEditContent] = useState("");
+
+  const providerOptions = [
+    { value: "google", label: t("settings.ai.providers.google") },
+    { value: "openai", label: t("settings.ai.providers.openai") },
+    { value: "claude", label: t("settings.ai.providers.claude") },
+    { value: "ollama", label: t("settings.ai.providers.ollama") },
+    { value: "custom", label: t("settings.ai.providers.custom") },
+  ];
+
+  const handleAddTemplate = () => {
+    if (!newTemplateName.trim() || !newTemplateContent.trim()) return;
+    addPromptTemplate(newTemplateName, newTemplateContent);
+    setNewTemplateName("");
+    setNewTemplateContent("");
+  };
+
+  const startEditing = (template: PromptTemplate) => {
+    setEditingTemplateId(template.id);
+    setEditName(template.name);
+    setEditContent(template.content);
+  };
+
+  const cancelEditing = () => {
+    setEditingTemplateId(null);
+    setEditName("");
+    setEditContent("");
+  };
+
+  const saveEditing = () => {
+    if (editingTemplateId && editName.trim() && editContent.trim()) {
+      updatePromptTemplate(editingTemplateId, { name: editName, content: editContent });
+      setEditingTemplateId(null);
+    }
+  };
+
+  const showApiKey = provider !== "ollama";
+  const showBaseUrl = provider === "ollama" || provider === "custom";
+
+  return (
+    <Stack gap="xl">
+      <div>
+        <Text size="xl" fw={600} mb="lg">
+          {t("settings.ai.title")}
+        </Text>
+        <Text size="sm" c="dimmed" mb="xl">
+          {t("settings.ai.description")}
+        </Text>
+
+        <Stack gap="lg">
+          {matchesSearch("provider model api key") && (
+            <>
+              <Select
+                label={t("settings.ai.provider")}
+                description={t("settings.ai.provider_desc")}
+                data={providerOptions}
+                value={provider}
+                onChange={(val) => setProvider((val as AIProvider) || "google")}
+                allowDeselect={false}
+              />
+
+              {showBaseUrl && (
+                <TextInput
+                  label={t("settings.ai.base_url")}
+                  description={t("settings.ai.base_url_desc")}
+                  value={baseUrl}
+                  onChange={(e) => setBaseUrl(e.currentTarget.value)}
+                  placeholder="http://localhost:11434"
+                />
+              )}
+
+              {showApiKey && (
+                <PasswordInput
+                  label={t("settings.ai.api_key")}
+                  description={t("settings.ai.api_key_desc")}
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.currentTarget.value)}
+                  placeholder="sk-..."
+                />
+              )}
+
+              <TextInput
+                label={t("settings.ai.model")}
+                description={t("settings.ai.model_desc")}
+                value={model}
+                onChange={(e) => setModel(e.currentTarget.value)}
+                placeholder="gpt-4, gemini-pro, llama3..."
+              />
+            </>
+          )}
+
+          {matchesSearch("prompt templates") && (
+            <div>
+              <Text size="sm" fw={500} mb="sm">
+                {t("settings.ai.templates")}
+              </Text>
+              <Text size="xs" c="dimmed" mb="md">
+                {t("settings.ai.templates_desc")}
+              </Text>
+
+              <Stack gap="sm">
+                {promptTemplates.length === 0 && (
+                  <Text size="sm" c="dimmed" fs="italic">
+                    {t("settings.ai.no_templates")}
+                  </Text>
+                )}
+
+                {promptTemplates.map((template) => (
+                  <Card key={template.id} withBorder padding="sm" radius="md">
+                    {editingTemplateId === template.id ? (
+                      <Stack gap="xs">
+                        <TextInput
+                          value={editName}
+                          onChange={(e) => setEditName(e.currentTarget.value)}
+                          placeholder={t("settings.ai.template_name_placeholder")}
+                        />
+                        <Textarea
+                          value={editContent}
+                          onChange={(e) => setEditContent(e.currentTarget.value)}
+                          placeholder={t("settings.ai.template_content_placeholder")}
+                          autosize
+                          minRows={2}
+                        />
+                        <Group justify="flex-end" gap="xs">
+                          <ActionIcon variant="light" color="red" onClick={cancelEditing}>
+                            <IconX size={16} />
+                          </ActionIcon>
+                          <ActionIcon variant="light" color="green" onClick={saveEditing}>
+                            <IconCheck size={16} />
+                          </ActionIcon>
+                        </Group>
+                      </Stack>
+                    ) : (
+                      <Group justify="space-between" align="flex-start">
+                        <div style={{ flex: 1 }}>
+                          <Text fw={500} size="sm">{template.name}</Text>
+                          <Text size="xs" c="dimmed" lineClamp={2}>
+                            {template.content}
+                          </Text>
+                        </div>
+                        <Group gap="xs">
+                          <ActionIcon variant="subtle" size="sm" onClick={() => startEditing(template)}>
+                            <IconPencil size={16} />
+                          </ActionIcon>
+                          <ActionIcon variant="subtle" color="red" size="sm" onClick={() => deletePromptTemplate(template.id)}>
+                            <IconTrash size={16} />
+                          </ActionIcon>
+                        </Group>
+                      </Group>
+                    )}
+                  </Card>
+                ))}
+
+                <Card withBorder padding="sm" radius="md" mt="sm" style={{ borderStyle: "dashed" }}>
+                  <Text size="sm" fw={500} mb="xs">{t("settings.ai.add_template")}</Text>
+                  <Stack gap="xs">
+                    <TextInput
+                      placeholder={t("settings.ai.template_name_placeholder")}
+                      value={newTemplateName}
+                      onChange={(e) => setNewTemplateName(e.currentTarget.value)}
+                    />
+                    <Textarea
+                      placeholder={t("settings.ai.template_content_placeholder")}
+                      value={newTemplateContent}
+                      onChange={(e) => setNewTemplateContent(e.currentTarget.value)}
+                      autosize
+                      minRows={2}
+                    />
+                    <Button 
+                      variant="light" 
+                      leftSection={<IconPlus size={16} />} 
+                      onClick={handleAddTemplate}
+                      disabled={!newTemplateName.trim() || !newTemplateContent.trim()}
+                    >
+                      {t("settings.ai.add_template")}
+                    </Button>
+                  </Stack>
+                </Card>
+              </Stack>
+            </div>
+          )}
+        </Stack>
+      </div>
+    </Stack>
+  );
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -82,6 +82,7 @@
       "homepage": "Homepage",
       "outliner": "Outliner",
       "version_control": "Version Control",
+      "ai": "AI Copilot",
       "shortcuts": "Shortcuts",
       "advanced": "Advanced",
       "about": "About",
@@ -198,6 +199,33 @@
       "push_pull_hint": "Push and pull buttons are available in the bottom-right corner",
       "remote_url_placeholder": "https://github.com/user/repo.git",
       "remove_remote_confirm": "Are you sure you want to remove the remote repository?"
+    },
+    "ai": {
+      "title": "AI Copilot",
+      "description": "Configure AI providers and prompt templates",
+      "provider": "AI Provider",
+      "provider_desc": "Select the AI service provider to use",
+      "api_key": "API Key",
+      "api_key_desc": "Enter your API key (stored locally)",
+      "base_url": "Base URL",
+      "base_url_desc": "Enter the base URL for the API (e.g., http://localhost:11434 for Ollama)",
+      "model": "Model Name",
+      "model_desc": "Enter the model name to use (e.g., gpt-4, gemini-pro, llama3)",
+      "templates": "Prompt Templates",
+      "templates_desc": "Manage custom prompt templates for quick access",
+      "add_template": "Add Template",
+      "template_name": "Template Name",
+      "template_content": "Template Content",
+      "template_name_placeholder": "e.g., Summarize",
+      "template_content_placeholder": "e.g., Summarize the following text...",
+      "no_templates": "No templates added yet",
+      "providers": {
+        "google": "Google Gemini",
+        "openai": "OpenAI",
+        "claude": "Anthropic Claude",
+        "ollama": "Ollama (Local)",
+        "custom": "Custom (OpenAI Compatible)"
+      }
     },
     "shortcuts": {
       "title": "Keyboard Shortcuts",

--- a/src/stores/aiSettingsStore.ts
+++ b/src/stores/aiSettingsStore.ts
@@ -1,0 +1,112 @@
+import { persist } from "zustand/middleware";
+import { createWithEqualityFn } from "zustand/traditional";
+import { v4 as uuidv4 } from "uuid";
+
+export type AIProvider = "google" | "openai" | "claude" | "ollama" | "custom";
+
+export interface PromptTemplate {
+  id: string;
+  name: string;
+  content: string;
+}
+
+interface AISettings {
+  provider: AIProvider;
+  apiKey: string;
+  baseUrl: string; // Mainly for Ollama or Custom (e.g., "http://localhost:11434")
+  model: string;
+  
+  // Custom Prompt Templates
+  promptTemplates: PromptTemplate[];
+}
+
+interface AISettingsStore extends AISettings {
+  setProvider: (provider: AIProvider) => void;
+  setApiKey: (key: string) => void;
+  setBaseUrl: (url: string) => void;
+  setModel: (model: string) => void;
+  
+  // Template Actions
+  addPromptTemplate: (name: string, content: string) => void;
+  updatePromptTemplate: (id: string, updates: Partial<Omit<PromptTemplate, "id">>) => void;
+  deletePromptTemplate: (id: string) => void;
+  
+  // Reset
+  resetSettings: () => void;
+}
+
+const DEFAULT_TEMPLATES: PromptTemplate[] = [
+  {
+    id: "default-summarize",
+    name: "Summarize",
+    content: "Summarize the following text concisely:",
+  },
+  {
+    id: "default-fix-grammar",
+    name: "Fix Grammar",
+    content: "Fix grammar and improve clarity of the following text:",
+  },
+  {
+    id: "default-translate-ko",
+    name: "Translate to Korean",
+    content: "Translate the following text to Korean:",
+  },
+  {
+    id: "default-translate-en",
+    name: "Translate to English",
+    content: "Translate the following text to English:",
+  },
+];
+
+const INITIAL_STATE: AISettings = {
+  provider: "google",
+  apiKey: "",
+  baseUrl: "http://localhost:11434", // Default Ollama port
+  model: "gemini-1.5-flash",
+  promptTemplates: DEFAULT_TEMPLATES,
+};
+
+export const useAISettingsStore = createWithEqualityFn<AISettingsStore>()(
+  persist(
+    (set) => ({
+      ...INITIAL_STATE,
+
+      setProvider: (provider) => set({ provider }),
+      setApiKey: (apiKey) => set({ apiKey }),
+      setBaseUrl: (baseUrl) => set({ baseUrl }),
+      setModel: (model) => set({ model }),
+
+      addPromptTemplate: (name, content) =>
+        set((state) => ({
+          promptTemplates: [
+            ...state.promptTemplates,
+            { id: uuidv4(), name, content },
+          ],
+        })),
+
+      updatePromptTemplate: (id, updates) =>
+        set((state) => ({
+          promptTemplates: state.promptTemplates.map((t) =>
+            t.id === id ? { ...t, ...updates } : t
+          ),
+        })),
+
+      deletePromptTemplate: (id) =>
+        set((state) => ({
+          promptTemplates: state.promptTemplates.filter((t) => t.id !== id),
+        })),
+        
+      resetSettings: () => set(INITIAL_STATE),
+    }),
+    {
+      name: "ai-settings",
+      partialize: (state) => ({
+        provider: state.provider,
+        apiKey: state.apiKey,
+        baseUrl: state.baseUrl,
+        model: state.model,
+        promptTemplates: state.promptTemplates,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
Adds 'AI' tab to Settings Modal with configuration for Providers (Google, OpenAI, Claude, Ollama) and Prompt Templates.

Closes #492