### PR TITLE
fix(i18n): add missing translation keys for context menu

### DIFF
--- a/src/components/BlockSelectionToolbar.tsx
+++ b/src/components/BlockSelectionToolbar.tsx
@@ -85,7 +85,7 @@ export const BlockSelectionToolbar: React.FC<BlockSelectionToolbarProps> = ({
       <Group gap="xs" ml="auto">
         {/* Indent Button */}
         <Tooltip
-          label={t("common.indent") || "Indent"}
+          label={t("common.indent")}
           withArrow
           position="top"
         >
@@ -102,7 +102,7 @@ export const BlockSelectionToolbar: React.FC<BlockSelectionToolbarProps> = ({
 
         {/* Outdent Button */}
         <Tooltip
-          label={t("common.outdent") || "Outdent"}
+          label={t("common.outdent")}
           withArrow
           position="top"
         >
@@ -132,7 +132,7 @@ export const BlockSelectionToolbar: React.FC<BlockSelectionToolbarProps> = ({
 
         {/* Delete Button */}
         <Tooltip
-          label={t("common.delete") || "Delete"}
+          label={t("common.delete")}
           withArrow
           position="top"
         >

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -47,6 +47,8 @@
       "blocks": "Blocks",
       "code_block": "Code Block",
       "indent": "Indent",
+      "outdent": "Outdent",
+      "duplicate": "Duplicate",
       "repository": "Repository",
       "git": "Git",
       "commit": "Commit",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -47,6 +47,8 @@
       "blocks": "블록",
       "code_block": "코드 블록",
       "indent": "들여쓰기",
+      "outdent": "내어쓰기",
+      "duplicate": "복제",
       "repository": "저장소",
       "git": "Git",
       "commit": "커밋",

--- a/src/outliner/BlockComponent.tsx
+++ b/src/outliner/BlockComponent.tsx
@@ -206,8 +206,8 @@ export const BlockComponent: React.FC<BlockComponentProps> = memo(
             },
             {
               label: isBatchOperation
-                ? `${t("common.outdent") || "Outdent"} (${targetBlocks.length})`
-                : t("common.outdent") || "Outdent",
+                ? `${t("common.outdent")} (${targetBlocks.length})`
+                : t("common.outdent"),
               icon: <IconIndentDecrease size={16} />,
               onClick: async () => {
                 for (const id of targetBlocks) {
@@ -221,10 +221,10 @@ export const BlockComponent: React.FC<BlockComponentProps> = memo(
             },
             {
               label: isBatchOperation
-                ? `${t("common.duplicate") || "Duplicate"} (${
+                ? `${t("common.duplicate")} (${
                     targetBlocks.length
                   })`
-                : t("common.duplicate") || "Duplicate",
+                : t("common.duplicate"),
               icon: <IconCopy size={16} />,
               onClick: async () => {
                 for (const id of targetBlocks) {


### PR DESCRIPTION
## Summary

Fix i18n missing keys that were causing context menu items to display raw translation keys instead of properly translated text.

## Changes

### Translation Files
- **ko.json**: Added `common.search_keywords.outdent` and `common.search_keywords.duplicate`
- **en.json**: Added `common.search_keywords.outdent` and `common.search_keywords.duplicate`

### Code Changes
- **BlockComponent.tsx**: Removed fallback strings `|| "Outdent"` and `|| "Duplicate"`
- **BlockSelectionToolbar.tsx**: Removed fallback strings `|| "Indent"`, `|| "Outdent"`, `|| "Delete"`

## Translation Keys Added

| Key | Korean (ko.json) | English (en.json) |
|------|-------------------|-------------------|
| `common.search_keywords.outdent` | "내어쓰기" | "Outdent" |
| `common.search_keywords.duplicate` | "복제" | "Duplicate" |

## Issue Description

Users were seeing raw translation keys like "common.outdent" or "common.duplicate" displayed in context menu items instead of properly translated text. This was due to:
1. Missing translation keys in both ko.json and en.json
2. Fallback strings in code (`|| "Outdent"`, `|| "Duplicate"`)

## Verification

- ✅ JSON structure validated for both translation files
- ✅ All changes committed
- ✅ Ready for review