### PR TITLE
fix(editor): prevent content duplication when splitting blocks with children

### DIFF
--- a/src/outliner/BlockComponent.tsx
+++ b/src/outliner/BlockComponent.tsx
@@ -619,16 +619,15 @@ export const BlockComponent: React.FC<BlockComponentProps> = memo(
           // Clear IME flag - we've processed the IME Enter
           imeStateRef.current.lastInputWasComposition = false;
 
-          // Execute block operation immediately since composition is already done
-          // For split, we pass the content directly to the store action to ensure atomic update
-          // For create (at end), we trigger save but can proceed with creation independently
-
           if (cursor === contentLength) {
             commitDraft().then(() => {
               createBlock(blockId);
             });
           } else {
-            // Pass current content to ensure split happens on the correct text
+            const beforeContent = content.slice(0, cursor);
+            draftRef.current = beforeContent;
+            setDraft(beforeContent);
+            
             splitBlockAtCursor(blockId, cursor, content);
           }
 
@@ -797,20 +796,16 @@ export const BlockComponent: React.FC<BlockComponentProps> = memo(
               return true;
             }
 
-            // Start async operations but return true immediately to prevent default behavior
-            // Determine whether to split block or create new sibling based on cursor position
             if (cursor === contentLength) {
-              // Cursor at end: create new sibling block
-              // Commit current block changes first
               commitDraft().then(() => {
                 createBlock(blockId);
               });
             } else {
-              // Cursor in middle: split current block
-              // Commit current block changes first, then split to ensure sync
-              commitDraft().then(() => {
-                splitBlockAtCursor(blockId, cursor, content);
-              });
+              const beforeContent = content.slice(0, cursor);
+              draftRef.current = beforeContent;
+              setDraft(beforeContent);
+              
+              splitBlockAtCursor(blockId, cursor, content);
             }
 
             return true; // Prevent default CodeMirror behavior


### PR DESCRIPTION
## Summary

Fixes the bug where pressing Enter in the middle of a block that has child blocks would duplicate content instead of properly splitting it.

## Problem

When splitting a block (pressing Enter in the middle of content) that had child blocks below:
- ✅ Works correctly: Splitting when the next block is a sibling
- ❌ Bug: Splitting when the next block is a child - content after cursor gets duplicated instead of moved

## Root Cause

The issue was caused by stale local draft state in BlockComponent:

1. When Enter is pressed, `commitDraft()` writes the full content to backend
2. Then `splitBlockAtCursor()` correctly updates the block with only `beforeContent`
3. **BUT** the local `draft` state still contained the full original content
4. When focus changes or any update occurs, `commitDraft()` gets called again via `handleBlur`
5. This overwrites the correctly split content with the stale full content

## Solution

Update the local draft state immediately before calling `splitBlockAtCursor`:

```typescript
const beforeContent = content.slice(0, cursor);
draftRef.current = beforeContent;
setDraft(beforeContent);

splitBlockAtCursor(blockId, cursor, content);
```

This prevents subsequent commits from overwriting the split content with stale data.

## Changes

- Updated both Enter key handlers (normal and IME composition paths) in `BlockComponent.tsx`
- Removed unnecessary comments per project style guidelines
- Local draft state now properly reflects the split operation immediately

## Testing

- ✅ TypeScript compilation passes
- ✅ Linter passes (Biome)
- ✅ Build succeeds
- Manual testing recommended: Split blocks with child blocks vs sibling blocks