### PR TITLE
feat(copilot): add resizable panel with drag handle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -215,6 +215,7 @@ function AppContent({ workspacePath }: AppContentProps) {
   } = useWorkspaceInitializer(workspacePath, openHomepage, setWorkspaceName);
 
   const copilotOpen = useCopilotUiStore((state) => state.isOpen);
+  const copilotPanelWidth = useCopilotUiStore((state) => state.panelWidth);
 
   // Register core commands
   useCoreCommands({
@@ -318,7 +319,7 @@ function AppContent({ workspacePath }: AppContentProps) {
       <AppShell
         padding={0}
         aside={{
-          width: 450,
+          width: copilotPanelWidth,
           breakpoint: "sm",
           collapsed: { mobile: !copilotOpen, desktop: !copilotOpen },
         }}

--- a/src/components/copilot/CopilotPanel.tsx
+++ b/src/components/copilot/CopilotPanel.tsx
@@ -46,6 +46,7 @@ import {
   MentionAutocomplete,
   type MentionSuggestion,
 } from "./MentionAutocomplete";
+import { ResizableHandle } from "./ResizableHandle";
 import { ToolApprovalModal } from "./ToolApprovalModal";
 
 export function CopilotPanel() {
@@ -69,6 +70,8 @@ export function CopilotPanel() {
   const setInputValue = useCopilotUiStore((state) => state.setInputValue);
   const isLoading = useCopilotUiStore((state) => state.isLoading);
   const setIsLoading = useCopilotUiStore((state) => state.setIsLoading);
+  const setPanelWidth = useCopilotUiStore((state) => state.setPanelWidth);
+  const panelWidth = useCopilotUiStore((state) => state.panelWidth);
 
   const chatMessages = useCopilotUiStore((state) => state.chatMessages);
   const addChatMessage = useCopilotUiStore((state) => state.addChatMessage);
@@ -336,6 +339,10 @@ export function CopilotPanel() {
 
   if (!isOpen) return null;
 
+  const handleResize = (deltaX: number) => {
+    setPanelWidth(panelWidth + deltaX);
+  };
+
   return (
     <Paper
       shadow="none"
@@ -346,8 +353,10 @@ export function CopilotPanel() {
         flexDirection: "column",
         borderLeft: "1px solid var(--color-border-primary)",
         backgroundColor: "var(--color-bg-primary)",
+        position: "relative",
       }}
     >
+      <ResizableHandle onResize={handleResize} />
       {/* Mention Autocomplete */}
       {mentionAutocomplete?.show && (
         <Portal>

--- a/src/components/copilot/ResizableHandle.tsx
+++ b/src/components/copilot/ResizableHandle.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+
+interface ResizableHandleProps {
+  onResize: (deltaX: number) => void;
+}
+
+export function ResizableHandle({ onResize }: ResizableHandleProps) {
+  const [isHovering, setIsHovering] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+
+    const startX = e.clientX;
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      const deltaX = startX - moveEvent.clientX;
+      onResize(deltaX);
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(false);
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+  };
+
+  return (
+    <div
+      onMouseDown={handleMouseDown}
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+      style={{
+        position: "absolute",
+        left: 0,
+        top: 0,
+        bottom: 0,
+        width: "4px",
+        cursor: "col-resize",
+        backgroundColor: isHovering || isDragging
+          ? "var(--color-border-secondary)"
+          : "var(--color-border-primary)",
+        transition: "background-color var(--transition-fast)",
+        zIndex: 10,
+      }}
+    />
+  );
+}

--- a/src/stores/copilotUiStore.ts
+++ b/src/stores/copilotUiStore.ts
@@ -17,6 +17,9 @@ interface CopilotUiStore {
   inputValue: string;
   isLoading: boolean;
 
+  // Panel Width
+  panelWidth: number;
+
   // Streaming Content State (for Preview)
   previewContent: string;
   originalContent: string | null; // For Undo/Diff
@@ -34,6 +37,7 @@ interface CopilotUiStore {
   setIsLoading: (loading: boolean) => void;
   setPreviewContent: (content: string) => void;
   setOriginalContent: (content: string | null) => void;
+  setPanelWidth: (width: number) => void;
 
   // Chat Actions
   addChatMessage: (
@@ -57,6 +61,7 @@ export const useCopilotUiStore = create<CopilotUiStore>((set) => ({
   originalContent: null,
   chatMessages: [],
   lastPageId: null,
+  panelWidth: 450,
 
   open: () => set({ isOpen: true }),
   close: () => set({ isOpen: false }),
@@ -67,6 +72,7 @@ export const useCopilotUiStore = create<CopilotUiStore>((set) => ({
   setIsLoading: (isLoading) => set({ isLoading }),
   setPreviewContent: (previewContent) => set({ previewContent }),
   setOriginalContent: (originalContent) => set({ originalContent }),
+  setPanelWidth: (width) => set({ panelWidth: Math.max(300, Math.min(800, width)) }),
 
   addChatMessage: (role, content) =>
     set((state) => ({


### PR DESCRIPTION
## Summary
- Added panelWidth state to copilotUiStore with min (300px) and max (800px) constraints
- Created ResizableHandle component with hover effect that brightens the divider on hover
- Enabled drag-to-resize functionality on the left edge of the copilot panel
- Updated App.tsx to use dynamic panel width from store instead of hardcoded 450px

## Changes
- **copilotUiStore**: Added panelWidth state (default: 450) with setPanelWidth action
- **ResizableHandle**: New component for drag-to-resize with visual hover feedback
- **CopilotPanel**: Integrated ResizableHandle on left edge with resize callback
- **App.tsx**: Replaced hardcoded width (450) with dynamic copilotPanelWidth from store

## Testing
- Hover effect works (divider brightens)
- Drag functionality respects min/max constraints (300-800px)
- Panel width persists in store during session