### PR TITLE
fix(ci): allow changeset generation even with existing pending changesets

### DIFF
--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -55,16 +55,10 @@ jobs:
             exit 0
           fi
 
-          # Check if there are already pending changesets (excluding README.md and config.json)
-          CHANGESET_COUNT=$(find .changeset -maxdepth 1 -name "*.md" ! -name "README.md" 2>/dev/null | wc -l | tr -d ' ')
-          
-          if [ "$CHANGESET_COUNT" -gt "0" ]; then
-            echo "Found $CHANGESET_COUNT pending changeset(s) - skipping new generation"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No pending changesets - will generate"
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+          # Always generate changeset for new commits
+          # Pending changesets will accumulate and be processed by the Version Packages PR
+          echo "Will generate changeset for new commits"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Generate Changeset
         if: steps.check_skip.outputs.skip == 'false'
@@ -86,7 +80,7 @@ jobs:
       - name: Skip changeset PR creation (workflow-generated commits only)
         if: steps.check_skip.outputs.skip == 'true'
         run: |
-          echo "No changeset needed - only workflow-generated commits since last release"
+          echo "No changeset needed - last commit is from github-actions bot"
 
       - name: Create or Update PR
         if: steps.check_skip.outputs.skip == 'false' && env.changeset_generated == 'true'


### PR DESCRIPTION
## Summary

- Fix auto-changeset workflow to generate changeset PRs even when pending changesets exist
- Remove the check that was blocking changeset generation when `.changeset/*.md` files already existed
- This allows the workflow to create individual changeset PRs for each merged PR, which then accumulate and get reflected in the Version Packages PR

## Problem

The auto-changeset workflow was detecting existing pending changesets (6 files) and skipping new changeset generation. This prevented creating new changeset PRs for new commits, breaking the automation flow:

1. PR merged to main → CI runs → Auto Changeset workflow runs
2. Workflow sees existing changesets → skips generation
3. No changeset PR created → changesets don't accumulate properly

## Solution

Modified the workflow logic to:
- Always generate changesets for new commits (unless from github-actions bot)
- Let the auto-changeset.cjs script handle duplicate detection via `.processed-commits` tracking
- Allow changesets to accumulate naturally, which the changesets bot will consolidate into the Version Packages PR

## Testing

- Verified the auto-changeset.cjs script tracks processed commits correctly
- Confirmed .processed-commits is gitignored as expected
- Workflow will now create changeset PRs that can be merged and reflected in PR #505